### PR TITLE
Updated the root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@ The Breeding API specifies a standard interface for plant phenotype/genotype dat
 Call | Description 
 ------------ | -------------
 [Authentication](https://github.com/plantbreeding/API/blob/master/Specification/Authentication/Authentication.md) | This resource refers to the authentication mechanism for the API.
-Calls | N.A.
-Crops | For multi crop systems this is a useful call to list all the supported crops.
-GenomeMaps | Retrieving genetic or physical maps
-Germplasm |  N.A.
-GermplasmAttributes | N.A.
-Locations | Location calls.
-MarkerProfiles | For the purposes of this API, the definition of markerprofile is *the allele calls for a specified germplasm line, for all markers, for a specified set of genotyping experiments or all experiments.*
-Markers |  N.A.
+Calls](https://github.com/plantbreeding/API/blob/master/Specification/ | N.A.
+Crops](https://github.com/plantbreeding/API/blob/master/Specification/ | For multi crop systems this is a useful call to list all the supported crops.
+GenomeMaps](https://github.com/plantbreeding/API/blob/master/Specification/ | Retrieving genetic or physical maps
+Germplasm](https://github.com/plantbreeding/API/blob/master/Specification/ |  N.A.
+GermplasmAttributes](https://github.com/plantbreeding/API/blob/master/Specification/ | N.A.
+Locations](https://github.com/plantbreeding/API/blob/master/Specification/ | Location calls.
+MarkerProfiles](https://github.com/plantbreeding/API/blob/master/Specification/ | For the purposes of this API, the definition of markerprofile is *the allele calls for a specified germplasm line, for all markers, for a specified set of genotyping experiments or all experiments.*
+Markers](https://github.com/plantbreeding/API/blob/master/Specification/ |  N.A.
 ObservationVariables | Observation variable data response
-Phenotypes | API to retrieve data (phenotype, environment variables) from studies. While the study calls focus on one study, calls in this section are for cross-study phenotypic data retrieval.
-Programs | N.A.
-Samples | API methods for traking/managing plant samples and realted metatdata. Sample in the context of these BrAPI calls, is defined as the actual bilogical plant material collected from the field.
-Studies | Study is defined as a phenotyping experiment conducted at a single geographic location. One Trial can have multiple studies conducted (e.g. multi location international trials).
-Traits | Services related to trials. Trials comprise of multiple studies.
-Trials | Services related to trials. Trials comprise of multiple studies.
+Phenotypes](https://github.com/plantbreeding/API/blob/master/Specification/ | API to retrieve data (phenotype, environment variables) from studies. While the study calls focus on one study, calls in this section are for cross-study phenotypic data retrieval.
+Programs](https://github.com/plantbreeding/API/blob/master/Specification/ | N.A.
+Samples](https://github.com/plantbreeding/API/blob/master/Specification/ | API methods for traking/managing plant samples and realted metatdata. Sample in the context of these BrAPI calls, is defined as the actual bilogical plant material collected from the field.
+Studies](https://github.com/plantbreeding/API/blob/master/Specification/ | Study is defined as a phenotyping experiment conducted at a single geographic location. One Trial can have multiple studies conducted (e.g. multi location international trials).
+Traits](https://github.com/plantbreeding/API/blob/master/Specification/ | Services related to trials. Trials comprise of multiple studies.
+Trials](https://github.com/plantbreeding/API/blob/master/Specification/ | Services related to trials. Trials comprise of multiple studies.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Repository for version control of the BrAPI specification
 ### INTRODUCTION
 
 
-The Breeding API specifies a standard interface for plant phenotype/genotype databases to serve their data to crop breeding applications. It is a shared, open API, to be used by all data providers and data consumers who wish to participate. Initiated in May 2014, it is currently in an actively developing state, so now is the time for potential participants to help shape the specifications to ensure their needs are addressed. The listserve for discussions and announcements is at http://mail2.sgn.cornell.edu/cgi-bin/mailman/listinfo/plant-breeding-api . Additional documentation is in the Github wiki.
+The Breeding API specifies a standard interface for plant phenotype/genotype databases to serve their data to crop breeding applications. It is a shared, open API, to be used by all data providers and data consumers who wish to participate. Initiated in May 2014, it is currently in an actively developing state, so now is the time for potential participants to help shape the specifications to ensure their needs are addressed. The listserve for discussions and announcements is [here](http://mail2.sgn.cornell.edu/cgi-bin/mailman/listinfo/plant-breeding-api). Additional documentation is in the [Github wiki](https://github.com/plantbreeding/API/wiki).
+For demos and implementations examples checkout [apiary documentation](http://docs.brapi.apiary.io/).
 
 
 Call | Description 
@@ -20,7 +21,7 @@ Call | Description
 [Markers](https://github.com/plantbreeding/API/blob/master/Specification/Markers/Markers.md) |  N.A.
 [ObservationVariables](https://github.com/plantbreeding/API/blob/master/Specification/ObservationVariables/ObservationVariables.md) | Observation variable data response
 [Phenotypes](https://github.com/plantbreeding/API/blob/master/Specification/Phenotypes/Phenotypes.md) | API to retrieve data (phenotype, environment variables) from studies. While the study calls focus on one study, calls in this section are for cross-study phenotypic data retrieval.
-[Programs](https://github.com/plantbreeding/API/blob/master/Specification/Programs/Programs.md) | N.A.
+[Programs](https://github.com/plantbreeding/API/blob/master/Specification/Programs/Programs.md) | Call to retrieve a list of programs.
 [Samples](https://github.com/plantbreeding/API/blob/master/Specification/Samples/Samples.md) | API methods for traking/managing plant samples and realted metatdata. Sample in the context of these BrAPI calls, is defined as the actual bilogical plant material collected from the field.
 [Studies](https://github.com/plantbreeding/API/blob/master/Specification/Studies/Studies.md) | Study is defined as a phenotyping experiment conducted at a single geographic location. One Trial can have multiple studies conducted (e.g. multi location international trials).
 [Traits](https://github.com/plantbreeding/API/blob/master/Specification/Traits/Traits.md) | Services related to trials. Trials comprise of multiple studies.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Breeding API specifies a standard interface for plant phenotype/genotype dat
 
 Call | Description 
 ------------ | -------------
-Authentication | This resource refers to the authentication mechanism for the API.
+[Authentication](https://github.com/plantbreeding/API/blob/master/Specification/Authentication/Authentication.md) | This resource refers to the authentication mechanism for the API.
 Calls | N.A.
 Crops | For multi crop systems this is a useful call to list all the supported crops.
 GenomeMaps | Retrieving genetic or physical maps

--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@ The Breeding API specifies a standard interface for plant phenotype/genotype dat
 Call | Description 
 ------------ | -------------
 [Authentication](https://github.com/plantbreeding/API/blob/master/Specification/Authentication/Authentication.md) | This resource refers to the authentication mechanism for the API.
-Calls](https://github.com/plantbreeding/API/blob/master/Specification/ | N.A.
-Crops](https://github.com/plantbreeding/API/blob/master/Specification/ | For multi crop systems this is a useful call to list all the supported crops.
-GenomeMaps](https://github.com/plantbreeding/API/blob/master/Specification/ | Retrieving genetic or physical maps
-Germplasm](https://github.com/plantbreeding/API/blob/master/Specification/ |  N.A.
-GermplasmAttributes](https://github.com/plantbreeding/API/blob/master/Specification/ | N.A.
-Locations](https://github.com/plantbreeding/API/blob/master/Specification/ | Location calls.
-MarkerProfiles](https://github.com/plantbreeding/API/blob/master/Specification/ | For the purposes of this API, the definition of markerprofile is *the allele calls for a specified germplasm line, for all markers, for a specified set of genotyping experiments or all experiments.*
-Markers](https://github.com/plantbreeding/API/blob/master/Specification/ |  N.A.
-ObservationVariables | Observation variable data response
-Phenotypes](https://github.com/plantbreeding/API/blob/master/Specification/ | API to retrieve data (phenotype, environment variables) from studies. While the study calls focus on one study, calls in this section are for cross-study phenotypic data retrieval.
-Programs](https://github.com/plantbreeding/API/blob/master/Specification/ | N.A.
-Samples](https://github.com/plantbreeding/API/blob/master/Specification/ | API methods for traking/managing plant samples and realted metatdata. Sample in the context of these BrAPI calls, is defined as the actual bilogical plant material collected from the field.
-Studies](https://github.com/plantbreeding/API/blob/master/Specification/ | Study is defined as a phenotyping experiment conducted at a single geographic location. One Trial can have multiple studies conducted (e.g. multi location international trials).
-Traits](https://github.com/plantbreeding/API/blob/master/Specification/ | Services related to trials. Trials comprise of multiple studies.
-Trials](https://github.com/plantbreeding/API/blob/master/Specification/ | Services related to trials. Trials comprise of multiple studies.
+[Calls](https://github.com/plantbreeding/API/blob/master/Specification/Calls/Calls.md) | N.A.
+[Crops](https://github.com/plantbreeding/API/blob/master/Specification/Crops/Crops.md) | For multi crop systems this is a useful call to list all the supported crops.
+[GenomeMaps](https://github.com/plantbreeding/API/blob/master/Specification/GenomeMaps/GenomeMaps.md) | Retrieving genetic or physical maps
+[Germplasm](https://github.com/plantbreeding/API/blob/master/Specification/Germplasm/Germplasm.md) |  N.A.
+[GermplasmAttributes](https://github.com/plantbreeding/API/blob/master/Specification/GermplasmAttributes/GermplasmAttributes.md) | N.A.
+[Locations](https://github.com/plantbreeding/API/blob/master/Specification/Locations/Locations.md) | Location calls.
+[MarkerProfiles](https://github.com/plantbreeding/API/blob/master/Specification/MarkerProfiles/MarkerProfiles.md) | For the purposes of this API, the definition of markerprofile is *the allele calls for a specified germplasm line, for all markers, for a specified set of genotyping experiments or all experiments.*
+[Markers](https://github.com/plantbreeding/API/blob/master/Specification/Markers/Markers.md) |  N.A.
+[ObservationVariables](https://github.com/plantbreeding/API/blob/master/Specification/ObservationVariables/ObservationVariables.md) | Observation variable data response
+[Phenotypes](https://github.com/plantbreeding/API/blob/master/Specification/Phenotypes/Phenotypes.md) | API to retrieve data (phenotype, environment variables) from studies. While the study calls focus on one study, calls in this section are for cross-study phenotypic data retrieval.
+[Programs](https://github.com/plantbreeding/API/blob/master/Specification/Programs/Programs.md) | N.A.
+[Samples](https://github.com/plantbreeding/API/blob/master/Specification/Samples/Samples.md) | API methods for traking/managing plant samples and realted metatdata. Sample in the context of these BrAPI calls, is defined as the actual bilogical plant material collected from the field.
+[Studies](https://github.com/plantbreeding/API/blob/master/Specification/Studies/Studies.md) | Study is defined as a phenotyping experiment conducted at a single geographic location. One Trial can have multiple studies conducted (e.g. multi location international trials).
+[Traits](https://github.com/plantbreeding/API/blob/master/Specification/Traits/Traits.md) | Services related to trials. Trials comprise of multiple studies.
+[Trials](https://github.com/plantbreeding/API/blob/master/Specification/Trials/Trials.md) | Services related to trials. Trials comprise of multiple studies.

--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@ Call | Description
 ------------ | -------------
 [Authentication](https://github.com/plantbreeding/API/blob/master/Specification/Authentication/Authentication.md) | This resource refers to the authentication mechanism for the API.
 [Calls](https://github.com/plantbreeding/API/blob/master/Specification/Calls/Calls.md) | N.A.
-[Crops](https://github.com/plantbreeding/API/blob/master/Specification/Crops/Crops.md) | For multi crop systems this is a useful call to list all the supported crops.
-[GenomeMaps](https://github.com/plantbreeding/API/blob/master/Specification/GenomeMaps/GenomeMaps.md) | Retrieving genetic or physical maps
-[Germplasm](https://github.com/plantbreeding/API/blob/master/Specification/Germplasm/Germplasm.md) |  N.A.
-[GermplasmAttributes](https://github.com/plantbreeding/API/blob/master/Specification/GermplasmAttributes/GermplasmAttributes.md) | N.A.
+[Crops](https://github.com/plantbreeding/API/blob/master/Specification/Crops/ListCrops.md) | For multi crop systems this is a useful call to list all the supported crops.
+[GenomeMaps](https://github.com/plantbreeding/API/blob/master/Specification/GenomeMaps/README.md) | Retrieving genetic or physical maps
+[Germplasm](https://github.com/plantbreeding/API/blob/master/Specification/Germplasm/GermplasmSearchGET.md) |  N.A.
+[GermplasmAttributes](https://github.com/plantbreeding/API/blob/master/Specification/GermplasmAttributes/ListAttributesByAttributeCategoryDbId.md) | N.A.
 [Locations](https://github.com/plantbreeding/API/blob/master/Specification/Locations/Locations.md) | Location calls.
-[MarkerProfiles](https://github.com/plantbreeding/API/blob/master/Specification/MarkerProfiles/MarkerProfiles.md) | For the purposes of this API, the definition of markerprofile is *the allele calls for a specified germplasm line, for all markers, for a specified set of genotyping experiments or all experiments.*
-[Markers](https://github.com/plantbreeding/API/blob/master/Specification/Markers/Markers.md) |  N.A.
-[ObservationVariables](https://github.com/plantbreeding/API/blob/master/Specification/ObservationVariables/ObservationVariables.md) | Observation variable data response
+[MarkerProfiles](https://github.com/plantbreeding/API/blob/master/Specification/MarkerProfiles/) | For the purposes of this API, the definition of markerprofile is *the allele calls for a specified germplasm line, for all markers, for a specified set of genotyping experiments or all experiments.*
+[Markers](https://github.com/plantbreeding/API/blob/master/Specification/Markers/MarkerSearch.md) |  N.A.
+[ObservationVariables](https://github.com/plantbreeding/API/blob/master/Specification/ObservationVariables/) | Observation variable data response
 [Phenotypes](https://github.com/plantbreeding/API/blob/master/Specification/Phenotypes/Phenotypes.md) | API to retrieve data (phenotype, environment variables) from studies. While the study calls focus on one study, calls in this section are for cross-study phenotypic data retrieval.
-[Programs](https://github.com/plantbreeding/API/blob/master/Specification/Programs/Programs.md) | Call to retrieve a list of programs.
-[Samples](https://github.com/plantbreeding/API/blob/master/Specification/Samples/Samples.md) | API methods for traking/managing plant samples and realted metatdata. Sample in the context of these BrAPI calls, is defined as the actual bilogical plant material collected from the field.
-[Studies](https://github.com/plantbreeding/API/blob/master/Specification/Studies/Studies.md) | Study is defined as a phenotyping experiment conducted at a single geographic location. One Trial can have multiple studies conducted (e.g. multi location international trials).
-[Traits](https://github.com/plantbreeding/API/blob/master/Specification/Traits/Traits.md) | Services related to trials. Trials comprise of multiple studies.
-[Trials](https://github.com/plantbreeding/API/blob/master/Specification/Trials/Trials.md) | Services related to trials. Trials comprise of multiple studies.
+[Programs](https://github.com/plantbreeding/API/blob/master/Specification/Programs/ProgramSearch.md) | Call to retrieve a list of programs.
+[Samples](https://github.com/plantbreeding/API/blob/master/Specification/Samples/) | API methods for traking/managing plant samples and realted metatdata. Sample in the context of these BrAPI calls, is defined as the actual bilogical plant material collected from the field.
+[Studies](https://github.com/plantbreeding/API/blob/master/Specification/Studies/StudyDetails.md) | Study is defined as a phenotyping experiment conducted at a single geographic location. One Trial can have multiple studies conducted (e.g. multi location international trials).
+[Traits](https://github.com/plantbreeding/API/blob/master/Specification/Traits/) | Services related to trials. Trials comprise of multiple studies.
+[Trials](https://github.com/plantbreeding/API/blob/master/Specification/Trials/) | Services related to trials. Trials comprise of multiple studies.

--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ For demos and implementations examples checkout [apiary documentation](http://do
 
 Call | Description 
 ------------ | -------------
-[Authentication](https://github.com/plantbreeding/API/blob/master/Specification/Authentication/Authentication.md) | This resource refers to the authentication mechanism for the API.
-[Calls](https://github.com/plantbreeding/API/blob/master/Specification/Calls/Calls.md) | N.A.
-[Crops](https://github.com/plantbreeding/API/blob/master/Specification/Crops/ListCrops.md) | For multi crop systems this is a useful call to list all the supported crops.
-[GenomeMaps](https://github.com/plantbreeding/API/blob/master/Specification/GenomeMaps/README.md) | Retrieving genetic or physical maps
-[Germplasm](https://github.com/plantbreeding/API/blob/master/Specification/Germplasm/GermplasmSearchGET.md) |  N.A.
-[GermplasmAttributes](https://github.com/plantbreeding/API/blob/master/Specification/GermplasmAttributes/ListAttributesByAttributeCategoryDbId.md) | N.A.
-[Locations](https://github.com/plantbreeding/API/blob/master/Specification/Locations/Locations.md) | Location calls.
+[Authentication](https://github.com/plantbreeding/API/blob/master/Specification/Authentication/) | This resource refers to the authentication mechanism for the API.
+[Calls](https://github.com/plantbreeding/API/blob/master/Specification/Calls/) | N.A.
+[Crops](https://github.com/plantbreeding/API/blob/master/Specification/Crops/) | For multi crop systems this is a useful call to list all the supported crops.
+[GenomeMaps](https://github.com/plantbreeding/API/blob/master/Specification/GenomeMaps/) | Retrieving genetic or physical maps
+[Germplasm](https://github.com/plantbreeding/API/blob/master/Specification/Germplasm/) |  N.A.
+[GermplasmAttributes](https://github.com/plantbreeding/API/blob/master/Specification/GermplasmAttributes/) | N.A.
+[Locations](https://github.com/plantbreeding/API/blob/master/Specification/Locations/) | Location calls.
 [MarkerProfiles](https://github.com/plantbreeding/API/blob/master/Specification/MarkerProfiles/) | For the purposes of this API, the definition of markerprofile is *the allele calls for a specified germplasm line, for all markers, for a specified set of genotyping experiments or all experiments.*
-[Markers](https://github.com/plantbreeding/API/blob/master/Specification/Markers/MarkerSearch.md) |  N.A.
+[Markers](https://github.com/plantbreeding/API/blob/master/Specification/Markers/) |  N.A.
 [ObservationVariables](https://github.com/plantbreeding/API/blob/master/Specification/ObservationVariables/) | Observation variable data response
-[Phenotypes](https://github.com/plantbreeding/API/blob/master/Specification/Phenotypes/Phenotypes.md) | API to retrieve data (phenotype, environment variables) from studies. While the study calls focus on one study, calls in this section are for cross-study phenotypic data retrieval.
-[Programs](https://github.com/plantbreeding/API/blob/master/Specification/Programs/ProgramSearch.md) | Call to retrieve a list of programs.
+[Phenotypes](https://github.com/plantbreeding/API/blob/master/Specification/Phenotypes/) | API to retrieve data (phenotype, environment variables) from studies. While the study calls focus on one study, calls in this section are for cross-study phenotypic data retrieval.
+[Programs](https://github.com/plantbreeding/API/blob/master/Specification/Programs/) | Call to retrieve a list of programs.
 [Samples](https://github.com/plantbreeding/API/blob/master/Specification/Samples/) | API methods for traking/managing plant samples and realted metatdata. Sample in the context of these BrAPI calls, is defined as the actual bilogical plant material collected from the field.
-[Studies](https://github.com/plantbreeding/API/blob/master/Specification/Studies/StudyDetails.md) | Study is defined as a phenotyping experiment conducted at a single geographic location. One Trial can have multiple studies conducted (e.g. multi location international trials).
+[Studies](https://github.com/plantbreeding/API/blob/master/Specification/Studies/) | Study is defined as a phenotyping experiment conducted at a single geographic location. One Trial can have multiple studies conducted (e.g. multi location international trials).
 [Traits](https://github.com/plantbreeding/API/blob/master/Specification/Traits/) | Services related to trials. Trials comprise of multiple studies.
 [Trials](https://github.com/plantbreeding/API/blob/master/Specification/Trials/) | Services related to trials. Trials comprise of multiple studies.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # BrAPI
 Repository for version control of the BrAPI specification
+
+### INTRODUCTION
+
+
+The Breeding API specifies a standard interface for plant phenotype/genotype databases to serve their data to crop breeding applications. It is a shared, open API, to be used by all data providers and data consumers who wish to participate. Initiated in May 2014, it is currently in an actively developing state, so now is the time for potential participants to help shape the specifications to ensure their needs are addressed. The listserve for discussions and announcements is at http://mail2.sgn.cornell.edu/cgi-bin/mailman/listinfo/plant-breeding-api . Additional documentation is in the Github wiki.
+
+
+Call | Description 
+------------ | -------------
+Authentication | This resource refers to the authentication mechanism for the API.
+Calls | N.A.
+Crops | For multi crop systems this is a useful call to list all the supported crops.
+GenomeMaps | Retrieving genetic or physical maps
+Germplasm |  N.A.
+GermplasmAttributes | N.A.
+Locations | Location calls.
+MarkerProfiles | For the purposes of this API, the definition of markerprofile is *the allele calls for a specified germplasm line, for all markers, for a specified set of genotyping experiments or all experiments.*
+Markers |  N.A.
+ObservationVariables | Observation variable data response
+Phenotypes | API to retrieve data (phenotype, environment variables) from studies. While the study calls focus on one study, calls in this section are for cross-study phenotypic data retrieval.
+Programs | N.A.
+Samples | API methods for traking/managing plant samples and realted metatdata. Sample in the context of these BrAPI calls, is defined as the actual bilogical plant material collected from the field.
+Studies | Study is defined as a phenotyping experiment conducted at a single geographic location. One Trial can have multiple studies conducted (e.g. multi location international trials).
+Traits | Services related to trials. Trials comprise of multiple studies.
+Trials | Services related to trials. Trials comprise of multiple studies.


### PR DESCRIPTION
I have added an intro that I got from apiary. And a list of call with links to the documentation specifications of each call. 

Links point to specific md files. But chould be changed to point to the root of the call directory instead. The pointing to specific files is because of the lack of info in the readme in most calls. 

Bruno Costa @ iBET