### PR TITLE
change markerProfileDbId to markerprofileDbId

### DIFF
--- a/Specification/Germplasm/GermplasmMarkerprofiles.md
+++ b/Specification/Germplasm/GermplasmMarkerprofiles.md
@@ -24,7 +24,7 @@ Implemented by: Germinate, Cassavabase
             },
             "result" :  {
                 germplasmDbId : 39393,
-                markerProfiles : [
+                markerprofileDbIds : [
                     3939, 4484, 3993
                 ]
             } 

--- a/Specification/Germplasm/GermplasmMarkerprofiles.md
+++ b/Specification/Germplasm/GermplasmMarkerprofiles.md
@@ -25,7 +25,7 @@ Implemented by: Germinate, Cassavabase
             "result" :  {
                 germplasmDbId : 39393,
                 markerprofileDbIds : [
-                    3939, 4484, 3993
+                    "3939", "4484", "3993"
                 ]
             } 
         }

--- a/Specification/MarkerProfiles/MarkerProfileAlleleMatrix.md
+++ b/Specification/MarkerProfiles/MarkerProfileAlleleMatrix.md
@@ -10,7 +10,7 @@ This uses a more efficient data structure and pagination for large number of mar
 |Variable|Datatype|Description|Required|  
 |------|------|------|:-----:|
 |markerprofileDbIds| list of strings | | Y |
-|data| array | Is an array of arrays; each inner array has three entries: "markerDbId", "markerProfileDbId", "alleleCall". Scores have to be represented as described further up. e.g. unknown data as "N", etc. Missing data can be skipped. | Y |
+|data| array | Is an array of arrays; each inner array has three entries: "markerDbId", "markerprofileDbId", "alleleCall". Scores have to be represented as described further up. e.g. unknown data as "N", etc. Missing data can be skipped. | Y |
 ### Scores through GET [GET]
 
 Use GET when parameter size is less than 2K bytes.

--- a/Specification/MarkerProfiles/MarkerProfileSearch.md
+++ b/Specification/MarkerProfiles/MarkerProfileSearch.md
@@ -33,7 +33,7 @@ For the requested Germplasm Id and/or Extract Id, returns the Markerprofile Id a
             "result" : {
                 "data" : [
                     {   
-                        "markerProfileDbId": "993",
+                        "markerprofileDbId": "993",
                         "germplasmDbId" : "2374",
                         "uniqueDisplayName": "MyFancyGermplasm",
                         "sampleDbId" : "3937",
@@ -42,7 +42,7 @@ For the requested Germplasm Id and/or Extract Id, returns the Markerprofile Id a
                         "resultCount": 1470
                     },
                     {
-                        "markerProfileDbId": "994",
+                        "markerprofileDbId": "994",
                         "germplasmDbId" : "2374",
                         "uniqueDisplayName" : "Germplasm2",
                         "sampleDbId" : "1234",

--- a/Specification/MarkerProfiles/MarkerProfileSearchPost.md
+++ b/Specification/MarkerProfiles/MarkerProfileSearchPost.md
@@ -29,7 +29,7 @@ For the requested Germplasm Ids and/or Extract Ids, returns the Markerprofile Id
             "result" : {
                 "data" : [
                     {   
-                        "markerProfileDbId": "993",
+                        "markerprofileDbId": "993",
                         "germplasmDbId" : "2374",
                         "uniqueDisplayName": "MyFancyGermplasm",
                         "sampleDbId" : "3937",
@@ -38,7 +38,7 @@ For the requested Germplasm Ids and/or Extract Ids, returns the Markerprofile Id
                         "resultCount": 1470
                     },
                     {
-                        "markerProfileDbId": "994",
+                        "markerprofileDbId": "994",
                         "germplasmDbId" : "2374",
                         "uniqueDisplayName" : "Germplasm2",
                         "sampleDbId" : "1234",


### PR DESCRIPTION
markerprofileDbId is used almost everywhere with a lowecase "p".

Also changed markerProfiles to markerprofileDbIds to match the rest of the specifications. (Not so sure about the final s, but the value is an array instead of the usual string)