### PR TITLE
Update LocationDetails.md correct pagination keys

### DIFF
--- a/Specification/Locations/LocationDetails.md
+++ b/Specification/Locations/LocationDetails.md
@@ -31,10 +31,10 @@ Get a list of locations.
         {
             "metadata": {
                 "pagination": { 
-                    "pageNumber": 1,
-                    "pageSize": 2,
-                    "totalCount": 100,
-                    "totalPages": 50
+                    "totalCount": 0,
+                    "pageSize": 0,
+                    "totalPages": 0,
+                    "currentPage": 0
                 },
                 "status" : [],
                 "datafiles": []


### PR DESCRIPTION
changed wrong "pageNumber" to "currentPage". This object cannot be paginated, so in this case, all the pagination object values are set to zero. Is this definition still valid?