### PR TITLE
Fixes formatting error - MD was not resolving

### DIFF
--- a/Specification/Studies/README.md
+++ b/Specification/Studies/README.md
@@ -807,7 +807,8 @@ Note: If 'observationUnitDbId' or 'observationDbId' is populated, they should be
         ]
     }
 }
-```+ Response 400 (application/json)
+```
++ Response 400 (application/json)
 ```
 {
     "metadata": {
@@ -852,7 +853,8 @@ Note: If 'observationUnitDbId' or 'observationDbId' is populated, they should be
         ]
     }
 }
-```+ Response 400 (application/json)
+```
++ Response 400 (application/json)
 ```
 {
     "metadata": {
@@ -1245,7 +1247,8 @@ observationTimestamp should be ISO8601 format with timezone: YYYY-MM-DDThh:mm:ss
 + Response 200 (application/csv)
 ```
 "year,studyDbId,studyName,locationDbId,locationName,germplasmDbId,germplasmName,observationUnitDbId,plotNumber,replicate,blockNumber,observationTimestamp,entryType,X,Y,variable1DbId,variable2DbId,variable3DbId\n2017,stu1,Study Name,loc1,Location Name,CIP1,CIP Name,abc123,1,1,1,2017-06-16T00:53:26Z,Test Entry,1,2,25.3,103.4,50.75 \n2017,stu1,Study Name,loc1,Location Name,CIP1,CIP Name,abc124,1,1,1,2017-06-16T00:54:57Z,Test Entry,2,2,27.9,98.65,45.345\n"
-```+ Response 200 (application/json)
+```
++ Response 200 (application/json)
 ```
 {
     "metadata": {
@@ -1330,7 +1333,8 @@ observationTimestamp should be ISO8601 format with timezone: YYYY-MM-DDThh:mm:ss
         ]
     }
 }
-```+ Response 200 (application/tsv)
+```
++ Response 200 (application/tsv)
 ```
 "year\tstudyDbId\tstudyName\tlocationDbId\tlocationName\tgermplasmDbId\tgermplasmName\tobservationUnitDbId\tplotNumber\treplicate\tblockNumber\tobservationTimestamp\tentryType\tX\tY\tvariable1DbId\tvariable2DbId\tvariable3DbId\n 2017\tstu1\tStudy Name\tloc1\tLocation Name\tCIP1\tCIP Name\tabc123\t1\t1\t1\t2017-06-16T00:53:26Z\tTest Entry\t1\t2\t25.3\t103.4\t50.75\n 2017\tstu1\tStudy Name\tloc1\tLocation Name\tCIP1\tCIP Name\tabc124\t1\t1\t1\t2017-06-16T00:54:57Z\tTest Entry\t2\t2\t27.9\t98.65\t45.345\n"
 ```


### PR DESCRIPTION
Was unreadable before fix.

Portions of text that were supposed to be in Markdown, were being considered code and JSON was being interpreted as MD.

