### PR TITLE
Update Germplasm_GET_POST.yaml

### DIFF
--- a/Specification/BrAPI-Germplasm/Germplasm/Germplasm_GET_POST.yaml
+++ b/Specification/BrAPI-Germplasm/Germplasm/Germplasm_GET_POST.yaml
@@ -103,14 +103,7 @@ paths:
       - Germplasm
     post:
       summary: Create new Germplasm entities on this server
-      description: |-
-        Addresses these needs
-        
-        - General germplasm search mechanism that accepts POST for complex queries 
-        
-        - Possibility to search germplasm by more parameters than those allowed by the existing germplasm search 
-        
-        - Possibility to get MCPD details by PUID rather than dbId
+      description: Create new Germplasm entities on this server
       parameters:
       - $ref: '#/components/parameters/authorizationHeader'
       requestBody:


### PR DESCRIPTION
The description of the /germplasm POST was a copy of the /search/germplasm POST.