### PR TITLE
One-dimensionalization of data models

### DIFF
--- a/Specification/BrAPI-Schema/BrAPI-Common/ExternalReference.json
+++ b/Specification/BrAPI-Schema/BrAPI-Common/ExternalReference.json
@@ -2,7 +2,7 @@
     "$defs": {
         "ExternalReference": {
             "properties": {
-                "referenceId": {
+                "externalReferenceDbId": {
                     "description": "The external reference ID. Could be a simple string or a URI.",
                     "type": [
                         "null",

--- a/Specification/BrAPI-Schema/BrAPI-Common/GeoJSON.json
+++ b/Specification/BrAPI-Schema/BrAPI-Common/GeoJSON.json
@@ -23,29 +23,29 @@
                     "description": "The literal string \"Feature\""
                 },
                 "image": {
-					"description": "Geometry associated with an image",
-					"$ref": "../BrAPI-Phenotyping/Image.json#/$defs/Image",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "imageLocation"
-				},
+                    "description": "Geometry associated with an image",
+                    "$ref": "../BrAPI-Phenotyping/Image.json#/$defs/Image",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "imageLocation"
+                },
                 "observation": {
-					"description": "Geometry associated with an image",
-					"$ref": "../BrAPI-Phenotyping/Observation.json#/$defs/Observation",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "geoCoordinates"
-				},
+                    "description": "Geometry associated with an image",
+                    "$ref": "../BrAPI-Phenotyping/Observation.json#/$defs/Observation",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "geoCoordinates"
+                },
                 "observationUnit": {
-					"description": "Geometry associated with an image",
-					"$ref": "../BrAPI-Phenotyping/ObservationUnit.json#/$defs/ObservationUnitPosition",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "geoCoordinates"
-				},
+                    "description": "Geometry associated with an image",
+                    "$ref": "../BrAPI-Phenotyping/ObservationUnit.json#/$defs/ObservationUnitPosition",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "geoCoordinates"
+                },
                 "germplasmOrigin": {
-					"description": "Geometry associated with an image",
-					"$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/GermplasmOrigin",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "coordinates"
-				}
+                    "description": "Geometry associated with an image",
+                    "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/GermplasmOrigin",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "coordinates"
+                }
             },
             "required": [
                 "geometryDbId"

--- a/Specification/BrAPI-Schema/BrAPI-Common/GeoJSON.json
+++ b/Specification/BrAPI-Schema/BrAPI-Common/GeoJSON.json
@@ -5,7 +5,7 @@
             "type": "object",
             "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.\n\nCopied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element.",
             "properties": {
-                "geometryDbId": {
+                "geoJSONDbId": {
                     "description": "Unique identifier for the geometry",
                     "type": [
                         "null",
@@ -48,7 +48,7 @@
                 }
             },
             "required": [
-                "geometryDbId"
+                "geoJSONDbId"
             ]
         }
     },

--- a/Specification/BrAPI-Schema/BrAPI-Common/GeoJSON.json
+++ b/Specification/BrAPI-Schema/BrAPI-Common/GeoJSON.json
@@ -5,6 +5,13 @@
             "type": "object",
             "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.\n\nCopied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element.",
             "properties": {
+                "geometryDbId": {
+                    "description": "Unique identifier for the geometry",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
                 "geometry": {
                     "description": "A geometry as defined by GeoJSON (RFC 7946). In this context, only Point or Polygon geometry are allowed.",
                     "$ref": "GeoJSONGeometry.json#/$defs/GeoJSONGeometry"
@@ -14,8 +21,35 @@
                     "default": "Feature",
                     "example": "Feature",
                     "description": "The literal string \"Feature\""
-                }
-            }
+                },
+                "image": {
+					"description": "Geometry associated with an image",
+					"$ref": "../BrAPI-Phenotyping/Image.json#/$defs/Image",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "imageLocation"
+				},
+                "observation": {
+					"description": "Geometry associated with an image",
+					"$ref": "../BrAPI-Phenotyping/Observation.json#/$defs/Observation",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "geoCoordinates"
+				},
+                "observationUnit": {
+					"description": "Geometry associated with an image",
+					"$ref": "../BrAPI-Phenotyping/ObservationUnit.json#/$defs/ObservationUnitPosition",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "geoCoordinates"
+				},
+                "germplasmOrigin": {
+					"description": "Geometry associated with an image",
+					"$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/GermplasmOrigin",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "coordinates"
+				}
+            },
+            "required": [
+                "geometryDbId"
+            ]
         }
     },
     "$id": "https://brapi.org/Specification/BrAPI-Schema/BrAPI-Common/GeoJSON.json",

--- a/Specification/BrAPI-Schema/BrAPI-Common/SourceGermplasm.json
+++ b/Specification/BrAPI-Schema/BrAPI-Common/SourceGermplasm.json
@@ -2,7 +2,7 @@
     "$defs": {
         "SourceGermplasm": {
             "properties": {
-                "germplasmDbId": {
+                "sourceGermplasmDbId": {
                     "description": "The ID which uniquely identifies a `Germplasm` within the given database server",
                     "type": [
                         "null",
@@ -30,7 +30,7 @@
                 }
             },
             "required": [
-                "germplasmDbId"
+                "sourceGermplasmDbId"
             ],
             "title": "sourceGermplasm",
             "type": "object",

--- a/Specification/BrAPI-Schema/BrAPI-Common/SourceGermplasm.json
+++ b/Specification/BrAPI-Schema/BrAPI-Common/SourceGermplasm.json
@@ -1,8 +1,8 @@
 {
     "$defs": {
         "SourceGermplasm": {
-			"properties": {
-				"germplasmDbId": {
+            "properties": {
+                "germplasmDbId": {
                     "description": "The ID which uniquely identifies a `Germplasm` within the given database server",
                     "type": [
                         "null",
@@ -16,20 +16,20 @@
                         "string"
                     ]
                 },
-				"reference": {
-					"description": "Germplasm associated with a reference",
-					"$ref": "../BrAPI-Genotyping/Reference.json#/$defs/Reference",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "sourceGermplasm"
-				},
+                "reference": {
+                    "description": "Germplasm associated with a reference",
+                    "$ref": "../BrAPI-Genotyping/Reference.json#/$defs/Reference",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "sourceGermplasm"
+                },
                 "referenceSet": {
-					"description": "Germplasm associated with a reference",
-					"$ref": "../BrAPI-Genotyping/ReferenceSet.json#/$defs/ReferenceSet",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "sourceGermplasm"
-				}
-			},
-			"required": [
+                    "description": "Germplasm associated with a reference",
+                    "$ref": "../BrAPI-Genotyping/ReferenceSet.json#/$defs/ReferenceSet",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "sourceGermplasm"
+                }
+            },
+            "required": [
                 "germplasmDbId"
             ],
             "title": "sourceGermplasm",
@@ -37,7 +37,7 @@
             "brapi-metadata": {
                 "primaryModel": false
             }
-		}
+        }
     },
     "$id": "https://brapi.org/Specification/BrAPI-Schema/BrAPI-Common/SourceGermplasm.json",
     "$schema": "http://json-schema.org/draft/2020-12/schema"

--- a/Specification/BrAPI-Schema/BrAPI-Common/SourceGermplasm.json
+++ b/Specification/BrAPI-Schema/BrAPI-Common/SourceGermplasm.json
@@ -1,0 +1,44 @@
+{
+    "$defs": {
+        "SourceGermplasm": {
+			"properties": {
+				"germplasmDbId": {
+                    "description": "The ID which uniquely identifies a `Germplasm` within the given database server",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "germplasmName": {
+                    "description": "The human readable name of a `Germplasm`",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+				"reference": {
+					"description": "Germplasm associated with a reference",
+					"$ref": "../BrAPI-Genotyping/Reference.json#/$defs/Reference",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "sourceGermplasm"
+				},
+                "referenceSet": {
+					"description": "Germplasm associated with a reference",
+					"$ref": "../BrAPI-Genotyping/ReferenceSet.json#/$defs/ReferenceSet",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "sourceGermplasm"
+				}
+			},
+			"required": [
+                "germplasmDbId"
+            ],
+            "title": "sourceGermplasm",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+		}
+    },
+    "$id": "https://brapi.org/Specification/BrAPI-Schema/BrAPI-Common/SourceGermplasm.json",
+    "$schema": "http://json-schema.org/draft/2020-12/schema"
+}

--- a/Specification/BrAPI-Schema/BrAPI-Common/SourceGermplasm.json
+++ b/Specification/BrAPI-Schema/BrAPI-Common/SourceGermplasm.json
@@ -2,13 +2,6 @@
     "$defs": {
         "SourceGermplasm": {
             "properties": {
-                "sourceGermplasmDbId": {
-                    "description": "The ID which uniquely identifies a `Germplasm` within the given database server",
-                    "type": [
-                        "null",
-                        "string"
-                    ]
-                },
                 "germplasmName": {
                     "description": "The human readable name of a `Germplasm`",
                     "type": [
@@ -29,9 +22,6 @@
                     "referencedAttribute": "sourceGermplasm"
                 }
             },
-            "required": [
-                "sourceGermplasmDbId"
-            ],
             "title": "sourceGermplasm",
             "type": "object",
             "brapi-metadata": {

--- a/Specification/BrAPI-Schema/BrAPI-Common/Species.json
+++ b/Specification/BrAPI-Schema/BrAPI-Common/Species.json
@@ -1,0 +1,51 @@
+{
+    "$defs": {
+        "Species": {
+			"properties": {
+				"specieDbId": {
+                    "description": "An ontology term describing an attribute.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "term": {
+                    "description": "Ontology term - the label of the ontology term the termId is pointing to.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "termURI": {
+                    "description": "Ontology term identifier - the CURIE for an ontology term. It differs from the standard GA4GH schema's :ref:`id ` in that it is a CURIE pointing to an information resource outside of the scope of the schema or its resource implementation.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+				"reference": {
+					"description": "Species associated with a reference",
+					"$ref": "../BrAPI-Genotyping/Reference.json#/$defs/Reference",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "species"
+				},
+                "referenceSet": {
+					"description": "Species associated with a referenceSet",
+					"$ref": "../BrAPI-Genotyping/ReferenceSet.json#/$defs/ReferenceSet",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "species"
+				}
+			},
+			"required": [
+                "specieDbId"
+            ],
+            "title": "OntologyTerm",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+		}
+    },
+    "$id": "https://brapi.org/Specification/BrAPI-Schema/BrAPI-Common/Species.json",
+    "$schema": "http://json-schema.org/draft/2020-12/schema"
+}

--- a/Specification/BrAPI-Schema/BrAPI-Common/Species.json
+++ b/Specification/BrAPI-Schema/BrAPI-Common/Species.json
@@ -1,8 +1,8 @@
 {
     "$defs": {
         "Species": {
-			"properties": {
-				"specieDbId": {
+            "properties": {
+                "specieDbId": {
                     "description": "An ontology term describing an attribute.",
                     "type": [
                         "null",
@@ -23,20 +23,20 @@
                         "string"
                     ]
                 },
-				"reference": {
-					"description": "Species associated with a reference",
-					"$ref": "../BrAPI-Genotyping/Reference.json#/$defs/Reference",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "species"
-				},
+                "reference": {
+                    "description": "Species associated with a reference",
+                    "$ref": "../BrAPI-Genotyping/Reference.json#/$defs/Reference",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "species"
+                },
                 "referenceSet": {
-					"description": "Species associated with a referenceSet",
-					"$ref": "../BrAPI-Genotyping/ReferenceSet.json#/$defs/ReferenceSet",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "species"
-				}
-			},
-			"required": [
+                    "description": "Species associated with a referenceSet",
+                    "$ref": "../BrAPI-Genotyping/ReferenceSet.json#/$defs/ReferenceSet",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "species"
+                }
+            },
+            "required": [
                 "specieDbId"
             ],
             "title": "OntologyTerm",
@@ -44,7 +44,7 @@
             "brapi-metadata": {
                 "primaryModel": false
             }
-		}
+        }
     },
     "$id": "https://brapi.org/Specification/BrAPI-Schema/BrAPI-Common/Species.json",
     "$schema": "http://json-schema.org/draft/2020-12/schema"

--- a/Specification/BrAPI-Schema/BrAPI-Common/Species.json
+++ b/Specification/BrAPI-Schema/BrAPI-Common/Species.json
@@ -2,7 +2,7 @@
     "$defs": {
         "Species": {
             "properties": {
-                "specieDbId": {
+                "speciesDbId": {
                     "description": "An ontology term describing an attribute.",
                     "type": [
                         "null",

--- a/Specification/BrAPI-Schema/BrAPI-Common/TraitDataType.json
+++ b/Specification/BrAPI-Schema/BrAPI-Common/TraitDataType.json
@@ -15,6 +15,6 @@
             "example": "Numerical"
         }
     },
-    "$id": "https://brapi.org/Specification/BrAPI-Schema/Components/Common/AdditionalInfo.json",
+    "$id": "https://brapi.org/Specification/BrAPI-Schema/Components/Common/TraitDataType.json",
     "$schema": "http://json-schema.org/draft/2020-12/schema"
 }

--- a/Specification/BrAPI-Schema/BrAPI-Common/Variable.json
+++ b/Specification/BrAPI-Schema/BrAPI-Common/Variable.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+					"relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "commonCropName": {
                     "description": "Crop name (examples: \"Maize\", \"Wheat\")",
@@ -40,8 +48,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [

--- a/Specification/BrAPI-Schema/BrAPI-Common/Variable.json
+++ b/Specification/BrAPI-Schema/BrAPI-Common/Variable.json
@@ -2,17 +2,17 @@
     "$defs": {
         "Variable": {
             "properties": {
-                "additionalInfo": {
-                    "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
+				"variableDbId": {
+                    "description": "Unique identifier for the Variable",
                     "type": [
                         "null",
-                        "array"
+                        "string"
                     ]
+                },
+                "additionalInfo": {
+                    "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "commonCropName": {
                     "description": "Crop name (examples: \"Maize\", \"Wheat\")",
@@ -82,14 +82,17 @@
                 },
                 "method": {
                     "description": "A description of the way an Observation should be collected. \n<br>For example, an ObservationVariable might be defined with a Trait of \"plant height\", a Scale of \"meters\", and a Method of \"tape measure\". This variable would be distinct from a variable with the Method \"estimation\" or \"drone image processing\". ",
+					"relationshipType": "one-to-one",
                     "$ref": "../BrAPI-Phenotyping/Method.json#/$defs/Method"
                 },
                 "ontologyReference": {
                     "description": "MIAPPE V1.1\n\n(DM-85) Variable accession number - Accession number of the variable in the Crop Ontology\n\n(DM-87) Trait accession number - Accession number of the trait in a suitable controlled vocabulary (Crop Ontology, Trait Ontology).\n\n(DM-89) Method accession number - Accession number of the method in a suitable controlled vocabulary (Crop Ontology, Trait Ontology).\n\n(DM-93) Scale accession number - Accession number of the scale in a suitable controlled vocabulary (Crop Ontology).",
+                    "relationshipType": "one-to-one",
                     "$ref": "../BrAPI-Phenotyping/OntologyReference.json#/$defs/OntologyReference"
                 },
                 "scale": {
                     "description": "A Scale describes the units and acceptable values for an ObservationVariable. \n<br>For example, an ObservationVariable might be defined with a Trait of \"plant height\", a Scale of \"meters\", and a Method of \"tape measure\". This variable would be distinct from a variable with the Scale \"inches\" or \"pixels\".",
+                    "relationshipType": "one-to-one",
                     "$ref": "../BrAPI-Phenotyping/Scale.json#/$defs/Scale"
                 },
                 "scientist": {
@@ -126,6 +129,7 @@
                 },
                 "trait": {
                     "description": "A Trait describes what property is being observed. \n<br>For example, an ObservationVariable might be defined with a Trait of \"plant height\", a Scale of \"meters\", and a Method of \"tape measure\". This variable would be distinct from a variable with the Trait \"Leaf length\" or \"Flower height\". ",
+                    "relationshipType": "one-to-one",
                     "$ref": "../BrAPI-Phenotyping/Trait.json#/$defs/Trait"
                 }
             },

--- a/Specification/BrAPI-Schema/BrAPI-Common/Variable.json
+++ b/Specification/BrAPI-Schema/BrAPI-Common/Variable.json
@@ -4,7 +4,7 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-					"relationshipType": "one-to-many",
+                    "relationshipType": "one-to-many",
                     "items": {
                         "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
                         "description": "AdditionalInfo"

--- a/Specification/BrAPI-Schema/BrAPI-Core/DataLink.json
+++ b/Specification/BrAPI-Schema/BrAPI-Core/DataLink.json
@@ -2,13 +2,6 @@
     "$defs": {
         "DataLink": {
             "properties": {
-				"dataLinkDbId": {
-                    "description": "The ID which uniquely identifies a data link",
-                    "type": [
-                        "null",
-                        "string"
-                    ]
-                },
                 "dataFormat": {
                     "description": "The structure of the data within a file. For example - VCF, table, image archive, multispectral image archives in EDAM ontology (used in Galaxy)\n\nMIAPPE V1.1 (DM-38) Data file description - Description of the format of the data file. May be a standard file format name, or a description of organization of the data in a tabular file.",
                     "type": [

--- a/Specification/BrAPI-Schema/BrAPI-Core/DataLink.json
+++ b/Specification/BrAPI-Schema/BrAPI-Core/DataLink.json
@@ -2,6 +2,13 @@
     "$defs": {
         "DataLink": {
             "properties": {
+				"dataLinkDbId": {
+                    "description": "The ID which uniquely identifies a data link",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
                 "dataFormat": {
                     "description": "The structure of the data within a file. For example - VCF, table, image archive, multispectral image archives in EDAM ontology (used in Galaxy)\n\nMIAPPE V1.1 (DM-38) Data file description - Description of the format of the data file. May be a standard file format name, or a description of organization of the data in a tabular file.",
                     "type": [

--- a/Specification/BrAPI-Schema/BrAPI-Core/List.json
+++ b/Specification/BrAPI-Schema/BrAPI-Core/List.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "data": {
                     "description": "The array of DbIds of the BrAPI objects contained in a List",
@@ -35,8 +43,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [

--- a/Specification/BrAPI-Schema/BrAPI-Core/List.json
+++ b/Specification/BrAPI-Schema/BrAPI-Core/List.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "data": {
                     "description": "The array of DbIds of the BrAPI objects contained in a List",

--- a/Specification/BrAPI-Schema/BrAPI-Core/Location.json
+++ b/Specification/BrAPI-Schema/BrAPI-Core/Location.json
@@ -11,7 +11,15 @@
                 },
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "coordinateDescription": {
                     "description": "Describes the precision and landmarks of the coordinate values used for a Location. (ex. the site, the nearest town, a 10 kilometers radius circle, +/- 20 meters, etc)",
@@ -69,8 +77,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [

--- a/Specification/BrAPI-Schema/BrAPI-Core/Location.json
+++ b/Specification/BrAPI-Schema/BrAPI-Core/Location.json
@@ -11,15 +11,8 @@
                 },
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "coordinateDescription": {
                     "description": "Describes the precision and landmarks of the coordinate values used for a Location. (ex. the site, the nearest town, a 10 kilometers radius circle, +/- 20 meters, etc)",
@@ -37,6 +30,7 @@
                 },
                 "coordinates": {
                     "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.\n\nCopied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element.",
+                    "relationshipType": "one-to-one",
                     "$ref": "../BrAPI-Common/GeoJSON.json#/$defs/GeoJSON"
                 },
                 "countryCode": {

--- a/Specification/BrAPI-Schema/BrAPI-Core/Person.json
+++ b/Specification/BrAPI-Schema/BrAPI-Core/Person.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "description": {
                     "description": "description of this person",

--- a/Specification/BrAPI-Schema/BrAPI-Core/Person.json
+++ b/Specification/BrAPI-Schema/BrAPI-Core/Person.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "description": {
                     "description": "description of this person",
@@ -22,8 +30,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [

--- a/Specification/BrAPI-Schema/BrAPI-Core/Program.json
+++ b/Specification/BrAPI-Schema/BrAPI-Core/Program.json
@@ -11,15 +11,8 @@
                 },
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "commonCropName": {
                     "description": "Common name for the crop which this program is for",

--- a/Specification/BrAPI-Schema/BrAPI-Core/Program.json
+++ b/Specification/BrAPI-Schema/BrAPI-Core/Program.json
@@ -11,7 +11,15 @@
                 },
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "commonCropName": {
                     "description": "Common name for the crop which this program is for",
@@ -30,8 +38,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [

--- a/Specification/BrAPI-Schema/BrAPI-Core/Study.json
+++ b/Specification/BrAPI-Schema/BrAPI-Core/Study.json
@@ -100,9 +100,12 @@
                 },
                 "growthFacility": {
                     "description": "Short description of the facility in which the study was carried out.",
-                    "relationshipType": "one-to-one",
+                    "relationshipType": "one-to-many",
                     "referencedAttribute": "study",
-					"$ref": "../BrAPI-Core/Study.json#/$defs/GrowthFacility"
+					"items": {
+						"$ref": "../BrAPI-Core/Study.json#/$defs/GrowthFacility",
+						"description": "GrowthFacility"
+					}
                 },
                 "lastUpdate": {
                     "description": "The date and time when this study was last modified",

--- a/Specification/BrAPI-Schema/BrAPI-Core/Study.json
+++ b/Specification/BrAPI-Schema/BrAPI-Core/Study.json
@@ -74,8 +74,8 @@
                 },
                 "environmentParameters": {
                     "description": "Environmental parameters that were kept constant throughout the study and did not change between observation units.\n\nMIAPPE V1.1 (DM-57) Environment - Environmental parameters that were kept constant throughout the study and did not change between observation units or assays. Environment characteristics that vary over time, i.e. environmental variables, should be recorded as Observed Variables (see below).",
-					"relationshipType": "one-to-many",
-					"referencedAttribute": "study",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "study",
                     "items": {
                         "$ref": "../BrAPI-Core/Study.json#/$defs/EnvironmentParameters",
                         "description": "EnvironmentParameters"
@@ -88,8 +88,8 @@
                 },
                 "experimentalDesign": {
                     "description": "The experimental and statistical design full description plus a category PUI taken from crop research ontology or agronomy ontology",
-					"relationshipType": "one-to-many",
-					"referencedAttribute": "study",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "study",
                     "items": {
                         "$ref": "../BrAPI-Core/Study.json#/$defs/ExperimentalDesign",
                         "description": "ExperimentalDesign"
@@ -115,8 +115,8 @@
                 },
                 "growthFacility": {
                     "description": "Short description of the facility in which the study was carried out.",
-					"relationshipType": "one-to-many",
-					"referencedAttribute": "study",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "study",
                     "items": {
                         "$ref": "../BrAPI-Core/Study.json#/$defs/GrowthFacility",
                         "description": "GrowthFacility"
@@ -129,8 +129,8 @@
                 },
                 "lastUpdate": {
                     "description": "The date and time when this study was last modified",
-					"relationshipType": "one-to-many",
-					"referencedAttribute": "study",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "study",
                     "items": {
                         "$ref": "../BrAPI-Core/Study.json#/$defs/LastUpdate",
                         "description": "LastUpdate"
@@ -156,8 +156,8 @@
                 },
                 "observationLevels": {
                     "description": "Observation levels indicate the granularity level at which the measurements are taken. `levelName` \ndefines the level, `levelOrder` defines where that level exists in the hierarchy of levels. \n`levelOrder`s lower numbers are at the top of the hierarchy (ie field > 0) and higher numbers are \nat the bottom of the hierarchy (ie plant > 6). \n\n**Standard Level Names: study, field, entry, rep, block, sub-block, plot, sub-plot, plant, pot, sample** \n\nFor more information on Observation Levels, please review the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Observation_Levels\">Observation Levels documentation</a>. ",
-					"relationshipType": "one-to-many",
-					"referencedAttribute": "study",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "study",
                     "items": {
                         "$ref": "../BrAPI-Core/Study.json#/$defs/ObservationLevels",
                         "description": "ObservationLevels"
@@ -354,12 +354,12 @@
             }
         },
         "EnvironmentParameters": {
-			"properties": {
-				"environmentParametersDbId": {
+            "properties": {
+                "environmentParametersDbId": {
                     "description": "Human-readable value of the environment parameter (defined above) constant within the experiment",
                     "type": "string"
-				},
-				"parameterName": {
+                },
+                "parameterName": {
                     "description": "Name of the environment parameter constant within the experiment\n\nMIAPPE V1.1 (DM-58) Environment parameter - Name of the environment parameter constant within the experiment. ",
                     "type": "string"
                 },
@@ -398,14 +398,14 @@
                         "string"
                     ]
                 },
-				"study": {
-					"description": "Enviroment parameters associated with a study",
-					"$ref": "../BrAPI-Core/Study.json#/$defs/Study",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "environmentParameters"
-				}
-			},
-			"required": [
+                "study": {
+                    "description": "Enviroment parameters associated with a study",
+                    "$ref": "../BrAPI-Core/Study.json#/$defs/Study",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "environmentParameters"
+                }
+            },
+            "required": [
                 "environmentParametersDbId",
                 "parameterName",
                 "description"
@@ -415,14 +415,14 @@
             "brapi-metadata": {
                 "primaryModel": false
             }
-		},
+        },
         "ExperimentalDesign": {
-			"properties": {
-				"experimentalDesignDbId": {
+            "properties": {
+                "experimentalDesignDbId": {
                     "description": "The experimental and statistical design full description plus a category PUI taken from crop research ontology or agronomy ontology",
                     "type": "string"
-				},
-				"PUI": {
+                },
+                "PUI": {
                     "description": "MIAPPE V1.1 (DM-23) Type of experimental design - Type of experimental  design of the study, in the form of an accession number from the Crop Ontology.",
                     "type": [
                         "null",
@@ -436,14 +436,14 @@
                         "string"
                     ]
                 },
-				"study": {
-					"description": "Experimental design associated with a study",
-					"$ref": "../BrAPI-Core/Study.json#/$defs/Study",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "experimentalDesign"
-				}
-			},
-			"required": [
+                "study": {
+                    "description": "Experimental design associated with a study",
+                    "$ref": "../BrAPI-Core/Study.json#/$defs/Study",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "experimentalDesign"
+                }
+            },
+            "required": [
                 "experimentalDesignDbId"
             ],
             "title": "ExperimentalDesign",
@@ -451,14 +451,14 @@
             "brapi-metadata": {
                 "primaryModel": false
             }
-		},
+        },
         "GrowthFacility": {
-			"properties": {
-				"growthFacilityDbId": {
+            "properties": {
+                "growthFacilityDbId": {
                     "description": "Short description of the facility in which the study was carried out.",
                     "type": "string"
-				},
-				"PUI": {
+                },
+                "PUI": {
                     "description": "MIAPPE V1.1 (DM-27) Type of growth facility - Type of growth facility in which the study was carried out, in the form of an accession number from the Crop Ontology.",
                     "type": [
                         "null",
@@ -472,14 +472,14 @@
                         "string"
                     ]
                 },
-				"study": {
-					"description": "Growth facility associated with a study",
-					"$ref": "../BrAPI-Core/Study.json#/$defs/Study",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "growthFacility"
-				}
-			},
-			"required": [
+                "study": {
+                    "description": "Growth facility associated with a study",
+                    "$ref": "../BrAPI-Core/Study.json#/$defs/Study",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "growthFacility"
+                }
+            },
+            "required": [
                 "growthFacilityDbId"
             ],
             "title": "GrowthFacility",
@@ -487,14 +487,14 @@
             "brapi-metadata": {
                 "primaryModel": false
             }
-		},
+        },
         "LastUpdate": {
-			"properties": {
-				"lastUpdateDbId": {
+            "properties": {
+                "lastUpdateDbId": {
                     "description": "The date and time when this study was last modified",
                     "type": "string"
-				},
-				"timestamp": {
+                },
+                "timestamp": {
                     "format": "date-time",
                     "type": [
                         "null",
@@ -507,14 +507,14 @@
                         "string"
                     ]
                 },
-				"study": {
-					"description": "Last update associated with a study",
-					"$ref": "../BrAPI-Core/Study.json#/$defs/Study",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "lastUpdate"
-				}
-			},
-			"required": [
+                "study": {
+                    "description": "Last update associated with a study",
+                    "$ref": "../BrAPI-Core/Study.json#/$defs/Study",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "lastUpdate"
+                }
+            },
+            "required": [
                 "lastUpdateDbId"
             ],
             "title": "LastUpdate",
@@ -522,14 +522,14 @@
             "brapi-metadata": {
                 "primaryModel": false
             }
-		},
+        },
         "ObservationLevels": {
-			"properties": {
-				"observationLevelsDbId": {
+            "properties": {
+                "observationLevelsDbId": {
                     "description": "Observation levels indicate the granularity level at which the measurements are taken. `levelName` defines the level, `levelOrder` defines where that level exists in the hierarchy of levels. `levelOrder`s lower numbers are at the top of the hierarchy (ie field > 0) and higher numbers are at the bottom of the hierarchy (ie plant > 6). ",
                     "type": "string"
-				},
-				"levelName": {
+                },
+                "levelName": {
                     "description": "A name for this level \n\n**Standard Level Names: study, field, entry, rep, block, sub-block, plot, sub-plot, plant, pot, sample** \n\nFor more information on Observation Levels, please review the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Observation_Levels\">Observation Levels documentation</a>. ",
                     "type": [
                         "null",
@@ -543,14 +543,14 @@
                         "integer"
                     ]
                 },
-				"study": {
-					"description": "Observation levels associated with a study",
-					"$ref": "../BrAPI-Core/Study.json#/$defs/Study",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "observationLevels"
-				}
-			},
-			"required": [
+                "study": {
+                    "description": "Observation levels associated with a study",
+                    "$ref": "../BrAPI-Core/Study.json#/$defs/Study",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "observationLevels"
+                }
+            },
+            "required": [
                 "observationLevelsDbId"
             ],
             "title": "ObservationUnitHierarchyLevel",
@@ -558,8 +558,7 @@
             "brapi-metadata": {
                 "primaryModel": false
             }
-		}
-    
+        }
     },
     "$id": "https://brapi.org/Specification/BrAPI-Schema/BrAPI-Core/Study.json",
     "$schema": "http://json-schema.org/draft/2020-12/schema"

--- a/Specification/BrAPI-Schema/BrAPI-Core/Study.json
+++ b/Specification/BrAPI-Schema/BrAPI-Core/Study.json
@@ -355,6 +355,10 @@
         },
         "EnvironmentParameters": {
             "properties": {
+                "description": {
+                    "description": "Human-readable value of the environment parameter (defined above) constant within the experiment",
+                    "type": "string"
+                },
                 "environmentParametersDbId": {
                     "description": "Human-readable value of the environment parameter (defined above) constant within the experiment",
                     "type": "string"
@@ -399,7 +403,7 @@
                     ]
                 },
                 "study": {
-                    "description": "Enviroment parameters associated with a study",
+                    "description": "Environment parameters associated with a study",
                     "$ref": "../BrAPI-Core/Study.json#/$defs/Study",
                     "relationshipType": "many-to-one",
                     "referencedAttribute": "environmentParameters"

--- a/Specification/BrAPI-Schema/BrAPI-Core/Study.json
+++ b/Specification/BrAPI-Schema/BrAPI-Core/Study.json
@@ -11,7 +11,15 @@
                 },
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "commonCropName": {
                     "description": "Common name for the crop associated with this study",
@@ -66,58 +74,13 @@
                 },
                 "environmentParameters": {
                     "description": "Environmental parameters that were kept constant throughout the study and did not change between observation units.\n\nMIAPPE V1.1 (DM-57) Environment - Environmental parameters that were kept constant throughout the study and did not change between observation units or assays. Environment characteristics that vary over time, i.e. environmental variables, should be recorded as Observed Variables (see below).",
+					"relationshipType": "one-to-many",
+					"referencedAttribute": "study",
                     "items": {
-                        "properties": {
-                            "description": {
-                                "description": "Human-readable value of the environment parameter (defined above) constant within the experiment",
-                                "type": "string"
-                            },
-                            "parameterName": {
-                                "description": "Name of the environment parameter constant within the experiment\n\nMIAPPE V1.1 (DM-58) Environment parameter - Name of the environment parameter constant within the experiment. ",
-                                "type": "string"
-                            },
-                            "parameterPUI": {
-                                "description": "URI pointing to an ontology class for the parameter",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "unit": {
-                                "description": "Unit of the value for this parameter",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "unitPUI": {
-                                "description": "URI pointing to an ontology class for the unit",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "value": {
-                                "description": "Numerical or categorical value\n\nMIAPPE V1.1 (DM-59) Environment parameter value - Value of the environment parameter (defined above) constant within the experiment.",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "valuePUI": {
-                                "description": "URI pointing to an ontology class for the parameter value",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "parameterName",
-                            "description"
-                        ],
-                        "type": "object"
+                        "$ref": "../BrAPI-Core/Study.json#/$defs/EnvironmentParameters",
+                        "description": "EnvironmentParameters"
                     },
+                    "title": "EnvironmentParameters",
                     "type": [
                         "null",
                         "array"
@@ -125,31 +88,24 @@
                 },
                 "experimentalDesign": {
                     "description": "The experimental and statistical design full description plus a category PUI taken from crop research ontology or agronomy ontology",
-                    "properties": {
-                        "PUI": {
-                            "description": "MIAPPE V1.1 (DM-23) Type of experimental design - Type of experimental  design of the study, in the form of an accession number from the Crop Ontology.",
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        },
-                        "description": {
-                            "description": "MIAPPE V1.1 (DM-22) Description of the experimental design - Short description of the experimental design, possibly including statistical design. In specific cases, e.g. legacy datasets or data computed from several studies, the experimental design can be \"unknown\"/\"NA\", \"aggregated/reduced data\", or simply 'none'.",
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        }
+					"relationshipType": "one-to-many",
+					"referencedAttribute": "study",
+                    "items": {
+                        "$ref": "../BrAPI-Core/Study.json#/$defs/ExperimentalDesign",
+                        "description": "ExperimentalDesign"
                     },
+                    "title": "ExperimentalDesign",
                     "type": [
                         "null",
-                        "object"
+                        "array"
                     ]
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [
@@ -159,47 +115,30 @@
                 },
                 "growthFacility": {
                     "description": "Short description of the facility in which the study was carried out.",
-                    "properties": {
-                        "PUI": {
-                            "description": "MIAPPE V1.1 (DM-27) Type of growth facility - Type of growth facility in which the study was carried out, in the form of an accession number from the Crop Ontology.",
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        },
-                        "description": {
-                            "description": "MIAPPE V1.1 (DM-26) Description of growth facility - Short description of the facility in which the study was carried out.",
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        }
+					"relationshipType": "one-to-many",
+					"referencedAttribute": "study",
+                    "items": {
+                        "$ref": "../BrAPI-Core/Study.json#/$defs/GrowthFacility",
+                        "description": "GrowthFacility"
                     },
+                    "title": "GrowthFacility",
                     "type": [
                         "null",
-                        "object"
+                        "array"
                     ]
                 },
                 "lastUpdate": {
                     "description": "The date and time when this study was last modified",
-                    "properties": {
-                        "timestamp": {
-                            "format": "date-time",
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        },
-                        "version": {
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        }
+					"relationshipType": "one-to-many",
+					"referencedAttribute": "study",
+                    "items": {
+                        "$ref": "../BrAPI-Core/Study.json#/$defs/LastUpdate",
+                        "description": "LastUpdate"
                     },
+                    "title": "LastUpdate",
                     "type": [
                         "null",
-                        "object"
+                        "array"
                     ]
                 },
                 "license": {
@@ -216,28 +155,14 @@
                     "relationshipType": "many-to-one"
                 },
                 "observationLevels": {
-                    "description": "Observation levels indicate the granularity level at which the measurements are taken. `levelName` defines the level, `levelOrder` defines where that level exists in the hierarchy of levels. `levelOrder`s lower numbers are at the top of the hierarchy (ie field > 0) and higher numbers are at the bottom of the hierarchy (ie plant > 6). ",
+                    "description": "Observation levels indicate the granularity level at which the measurements are taken. `levelName` \ndefines the level, `levelOrder` defines where that level exists in the hierarchy of levels. \n`levelOrder`s lower numbers are at the top of the hierarchy (ie field > 0) and higher numbers are \nat the bottom of the hierarchy (ie plant > 6). \n\n**Standard Level Names: study, field, entry, rep, block, sub-block, plot, sub-plot, plant, pot, sample** \n\nFor more information on Observation Levels, please review the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Observation_Levels\">Observation Levels documentation</a>. ",
+					"relationshipType": "one-to-many",
+					"referencedAttribute": "study",
                     "items": {
-                        "description": "Observation levels indicate the granularity level at which the measurements are taken. `levelName` \ndefines the level, `levelOrder` defines where that level exists in the hierarchy of levels. \n`levelOrder`s lower numbers are at the top of the hierarchy (ie field > 0) and higher numbers are \nat the bottom of the hierarchy (ie plant > 6). \n\n**Standard Level Names: study, field, entry, rep, block, sub-block, plot, sub-plot, plant, pot, sample** \n\nFor more information on Observation Levels, please review the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Observation_Levels\">Observation Levels documentation</a>. ",
-                        "properties": {
-                            "levelName": {
-                                "description": "A name for this level \n\n**Standard Level Names: study, field, entry, rep, block, sub-block, plot, sub-plot, plant, pot, sample** \n\nFor more information on Observation Levels, please review the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Observation_Levels\">Observation Levels documentation</a>. ",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "levelOrder": {
-                                "description": "`levelOrder` defines where that level exists in the hierarchy of levels. `levelOrder`'s lower numbers \nare at the top of the hierarchy (ie field -> 1) and higher numbers are at the bottom of the hierarchy (ie plant -> 9). \n\nFor more information on Observation Levels, please review the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Observation_Levels\">Observation Levels documentation</a>. ",
-                                "type": [
-                                    "null",
-                                    "integer"
-                                ]
-                            }
-                        },
-                        "title": "ObservationUnitHierarchyLevel",
-                        "type": "object"
+                        "$ref": "../BrAPI-Core/Study.json#/$defs/ObservationLevels",
+                        "description": "ObservationLevels"
                     },
+                    "title": "ObservationLevels",
                     "type": [
                         "null",
                         "array"
@@ -427,7 +352,214 @@
             "brapi-metadata": {
                 "primaryModel": true
             }
-        }
+        },
+        "EnvironmentParameters": {
+			"properties": {
+				"environmentParametersDbId": {
+                    "description": "Human-readable value of the environment parameter (defined above) constant within the experiment",
+                    "type": "string"
+				},
+				"parameterName": {
+                    "description": "Name of the environment parameter constant within the experiment\n\nMIAPPE V1.1 (DM-58) Environment parameter - Name of the environment parameter constant within the experiment. ",
+                    "type": "string"
+                },
+                "parameterPUI": {
+                    "description": "URI pointing to an ontology class for the parameter",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "unit": {
+                    "description": "Unit of the value for this parameter",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "unitPUI": {
+                    "description": "URI pointing to an ontology class for the unit",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "value": {
+                    "description": "Numerical or categorical value\n\nMIAPPE V1.1 (DM-59) Environment parameter value - Value of the environment parameter (defined above) constant within the experiment.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "valuePUI": {
+                    "description": "URI pointing to an ontology class for the parameter value",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+				"study": {
+					"description": "Enviroment parameters associated with a study",
+					"$ref": "../BrAPI-Core/Study.json#/$defs/Study",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "environmentParameters"
+				}
+			},
+			"required": [
+                "environmentParametersDbId",
+                "parameterName",
+                "description"
+            ],
+            "title": "EnvironmentParameters",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+		},
+        "ExperimentalDesign": {
+			"properties": {
+				"experimentalDesignDbId": {
+                    "description": "The experimental and statistical design full description plus a category PUI taken from crop research ontology or agronomy ontology",
+                    "type": "string"
+				},
+				"PUI": {
+                    "description": "MIAPPE V1.1 (DM-23) Type of experimental design - Type of experimental  design of the study, in the form of an accession number from the Crop Ontology.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "description": {
+                    "description": "MIAPPE V1.1 (DM-22) Description of the experimental design - Short description of the experimental design, possibly including statistical design. In specific cases, e.g. legacy datasets or data computed from several studies, the experimental design can be \"unknown\"/\"NA\", \"aggregated/reduced data\", or simply 'none'.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+				"study": {
+					"description": "Experimental design associated with a study",
+					"$ref": "../BrAPI-Core/Study.json#/$defs/Study",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "experimentalDesign"
+				}
+			},
+			"required": [
+                "experimentalDesignDbId"
+            ],
+            "title": "ExperimentalDesign",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+		},
+        "GrowthFacility": {
+			"properties": {
+				"growthFacilityDbId": {
+                    "description": "Short description of the facility in which the study was carried out.",
+                    "type": "string"
+				},
+				"PUI": {
+                    "description": "MIAPPE V1.1 (DM-27) Type of growth facility - Type of growth facility in which the study was carried out, in the form of an accession number from the Crop Ontology.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "description": {
+                    "description": "MIAPPE V1.1 (DM-26) Description of growth facility - Short description of the facility in which the study was carried out.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+				"study": {
+					"description": "Growth facility associated with a study",
+					"$ref": "../BrAPI-Core/Study.json#/$defs/Study",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "growthFacility"
+				}
+			},
+			"required": [
+                "growthFacilityDbId"
+            ],
+            "title": "GrowthFacility",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+		},
+        "LastUpdate": {
+			"properties": {
+				"lastUpdateDbId": {
+                    "description": "The date and time when this study was last modified",
+                    "type": "string"
+				},
+				"timestamp": {
+                    "format": "date-time",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "version": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+				"study": {
+					"description": "Last update associated with a study",
+					"$ref": "../BrAPI-Core/Study.json#/$defs/Study",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "lastUpdate"
+				}
+			},
+			"required": [
+                "lastUpdateDbId"
+            ],
+            "title": "LastUpdate",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+		},
+        "ObservationLevels": {
+			"properties": {
+				"observationLevelsDbId": {
+                    "description": "Observation levels indicate the granularity level at which the measurements are taken. `levelName` defines the level, `levelOrder` defines where that level exists in the hierarchy of levels. `levelOrder`s lower numbers are at the top of the hierarchy (ie field > 0) and higher numbers are at the bottom of the hierarchy (ie plant > 6). ",
+                    "type": "string"
+				},
+				"levelName": {
+                    "description": "A name for this level \n\n**Standard Level Names: study, field, entry, rep, block, sub-block, plot, sub-plot, plant, pot, sample** \n\nFor more information on Observation Levels, please review the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Observation_Levels\">Observation Levels documentation</a>. ",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "levelOrder": {
+                    "description": "`levelOrder` defines where that level exists in the hierarchy of levels. `levelOrder`'s lower numbers \nare at the top of the hierarchy (ie field -> 1) and higher numbers are at the bottom of the hierarchy (ie plant -> 9). \n\nFor more information on Observation Levels, please review the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Observation_Levels\">Observation Levels documentation</a>. ",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+				"study": {
+					"description": "Observation levels associated with a study",
+					"$ref": "../BrAPI-Core/Study.json#/$defs/Study",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "observationLevels"
+				}
+			},
+			"required": [
+                "observationLevelsDbId"
+            ],
+            "title": "ObservationUnitHierarchyLevel",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+		}
+    
     },
     "$id": "https://brapi.org/Specification/BrAPI-Schema/BrAPI-Core/Study.json",
     "$schema": "http://json-schema.org/draft/2020-12/schema"

--- a/Specification/BrAPI-Schema/BrAPI-Core/Study.json
+++ b/Specification/BrAPI-Schema/BrAPI-Core/Study.json
@@ -11,15 +11,8 @@
                 },
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "commonCropName": {
                     "description": "Common name for the crop associated with this study",
@@ -88,17 +81,9 @@
                 },
                 "experimentalDesign": {
                     "description": "The experimental and statistical design full description plus a category PUI taken from crop research ontology or agronomy ontology",
-                    "relationshipType": "one-to-many",
+                    "relationshipType": "one-to-one",
                     "referencedAttribute": "study",
-                    "items": {
-                        "$ref": "../BrAPI-Core/Study.json#/$defs/ExperimentalDesign",
-                        "description": "ExperimentalDesign"
-                    },
-                    "title": "ExperimentalDesign",
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Core/Study.json#/$defs/ExperimentalDesign"
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
@@ -115,31 +100,15 @@
                 },
                 "growthFacility": {
                     "description": "Short description of the facility in which the study was carried out.",
-                    "relationshipType": "one-to-many",
+                    "relationshipType": "one-to-one",
                     "referencedAttribute": "study",
-                    "items": {
-                        "$ref": "../BrAPI-Core/Study.json#/$defs/GrowthFacility",
-                        "description": "GrowthFacility"
-                    },
-                    "title": "GrowthFacility",
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+					"$ref": "../BrAPI-Core/Study.json#/$defs/GrowthFacility"
                 },
                 "lastUpdate": {
                     "description": "The date and time when this study was last modified",
-                    "relationshipType": "one-to-many",
+                    "relationshipType": "one-to-one",
                     "referencedAttribute": "study",
-                    "items": {
-                        "$ref": "../BrAPI-Core/Study.json#/$defs/LastUpdate",
-                        "description": "LastUpdate"
-                    },
-                    "title": "LastUpdate",
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Core/Study.json#/$defs/LastUpdate"
                 },
                 "license": {
                     "description": "The usage license associated with the study data",

--- a/Specification/BrAPI-Schema/BrAPI-Core/Trial.json
+++ b/Specification/BrAPI-Schema/BrAPI-Core/Trial.json
@@ -41,8 +41,8 @@
                 },
                 "datasetAuthorships": {
                     "description": "License and citation information for the data in this trial",
-					"relationshipType": "one-to-many",
-					"referencedAttribute": "trial",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "trial",
                     "items": {
                         "$ref": "../BrAPI-Core/Trial.json#/$defs/DatasetAuthorships",
                         "description": "DatasetAuthorships"
@@ -103,8 +103,8 @@
                 },
                 "publications": {
                     "description": "MIAPPE V1.1 (DM-9) Associated publication - An identifier for a literature publication where the investigation is described. Use of DOIs is recommended.",
-					"relationshipType": "one-to-many",
-					"referencedAttribute": "trial",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "trial",
                     "items": {
                         "$ref": "../BrAPI-Core/Trial.json#/$defs/Publications",
                         "description": "Publications"
@@ -198,12 +198,12 @@
             }
         },
         "DatasetAuthorships": {
-			"properties": {
-				"datasetAuthorshipsDbId": {
+            "properties": {
+                "datasetAuthorshipsDbId": {
                     "description": "License and citation information for the data in this trial",
                     "type": "string"
-				},
-				"datasetPUI": {
+                },
+                "datasetPUI": {
                     "description": "The DOI or other permanent unique identifier for this published dataset",
                     "type": [
                         "null",
@@ -231,14 +231,14 @@
                         "string"
                     ]
                 },
-				"trial": {
-					"description": "Dataset authorships associated with a trial",
-					"$ref": "../BrAPI-Core/Trial.json#/$defs/Trial",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "datasetAuthorships"
-				}
-			},
-			"required": [
+                "trial": {
+                    "description": "Dataset authorships associated with a trial",
+                    "$ref": "../BrAPI-Core/Trial.json#/$defs/Trial",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "datasetAuthorships"
+                }
+            },
+            "required": [
                 "datasetAuthorshipsDbId"
             ],
             "title": "DatasetAuthorships",
@@ -246,14 +246,14 @@
             "brapi-metadata": {
                 "primaryModel": false
             }
-		},
+        },
         "Publications": {
-			"properties": {
-				"publicationsDbId": {
+            "properties": {
+                "publicationsDbId": {
                     "description": "MIAPPE V1.1 (DM-9) Associated publication - An identifier for a literature publication where the investigation is described. Use of DOIs is recommended.",
                     "type": "string"
-				},
-				"publicationPUI": {
+                },
+                "publicationPUI": {
                     "type": [
                         "null",
                         "string"
@@ -265,14 +265,14 @@
                         "string"
                     ]
                 },
-				"trial": {
-					"description": "Publications associated with a trial",
-					"$ref": "../BrAPI-Core/Trial.json#/$defs/Trial",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "publications"
-				}
-			},
-			"required": [
+                "trial": {
+                    "description": "Publications associated with a trial",
+                    "$ref": "../BrAPI-Core/Trial.json#/$defs/Trial",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "publications"
+                }
+            },
+            "required": [
                 "publicationsDbId"
             ],
             "title": "Publications",
@@ -280,7 +280,7 @@
             "brapi-metadata": {
                 "primaryModel": false
             }
-		}
+        }
     },
     "$id": "https://brapi.org/Specification/BrAPI-Schema/BrAPI-Core/Trial.json",
     "$schema": "http://json-schema.org/draft/2020-12/schema"

--- a/Specification/BrAPI-Schema/BrAPI-Core/Trial.json
+++ b/Specification/BrAPI-Schema/BrAPI-Core/Trial.json
@@ -11,15 +11,8 @@
                 },
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "commonCropName": {
                     "description": "Common name for the crop associated with this trial",

--- a/Specification/BrAPI-Schema/BrAPI-Core/Trial.json
+++ b/Specification/BrAPI-Schema/BrAPI-Core/Trial.json
@@ -11,7 +11,15 @@
                 },
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "commonCropName": {
                     "description": "Common name for the crop associated with this trial",
@@ -33,39 +41,13 @@
                 },
                 "datasetAuthorships": {
                     "description": "License and citation information for the data in this trial",
+					"relationshipType": "one-to-many",
+					"referencedAttribute": "trial",
                     "items": {
-                        "properties": {
-                            "datasetPUI": {
-                                "description": "The DOI or other permanent unique identifier for this published dataset",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "license": {
-                                "description": "MIAPPE V1.1 (DM-7) License - License for the reuse of the data associated with this investigation. The Creative Commons licenses cover most use cases and are recommended.",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "publicReleaseDate": {
-                                "description": "MIAPPE V1.1 (DM-6) Public release date - Date of first public release of the dataset presently being described.",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "submissionDate": {
-                                "description": "MIAPPE V1.1 (DM-5) Submission date - Date of submission of the dataset presently being described to a host repository.",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "../BrAPI-Core/Trial.json#/$defs/DatasetAuthorships",
+                        "description": "DatasetAuthorships"
                     },
+                    "title": "DatasetAuthorships",
                     "type": [
                         "null",
                         "array"
@@ -88,8 +70,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [
@@ -119,23 +103,13 @@
                 },
                 "publications": {
                     "description": "MIAPPE V1.1 (DM-9) Associated publication - An identifier for a literature publication where the investigation is described. Use of DOIs is recommended.",
+					"relationshipType": "one-to-many",
+					"referencedAttribute": "trial",
                     "items": {
-                        "properties": {
-                            "publicationPUI": {
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "publicationReference": {
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "../BrAPI-Core/Trial.json#/$defs/Publications",
+                        "description": "Publications"
                     },
+                    "title": "Publications",
                     "type": [
                         "null",
                         "array"
@@ -222,7 +196,91 @@
             "brapi-metadata": {
                 "primaryModel": true
             }
-        }
+        },
+        "DatasetAuthorships": {
+			"properties": {
+				"datasetAuthorshipsDbId": {
+                    "description": "License and citation information for the data in this trial",
+                    "type": "string"
+				},
+				"datasetPUI": {
+                    "description": "The DOI or other permanent unique identifier for this published dataset",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "license": {
+                    "description": "MIAPPE V1.1 (DM-7) License - License for the reuse of the data associated with this investigation. The Creative Commons licenses cover most use cases and are recommended.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "publicReleaseDate": {
+                    "description": "MIAPPE V1.1 (DM-6) Public release date - Date of first public release of the dataset presently being described.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "submissionDate": {
+                    "description": "MIAPPE V1.1 (DM-5) Submission date - Date of submission of the dataset presently being described to a host repository.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+				"trial": {
+					"description": "Dataset authorships associated with a trial",
+					"$ref": "../BrAPI-Core/Trial.json#/$defs/Trial",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "datasetAuthorships"
+				}
+			},
+			"required": [
+                "datasetAuthorshipsDbId"
+            ],
+            "title": "DatasetAuthorships",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+		},
+        "Publications": {
+			"properties": {
+				"publicationsDbId": {
+                    "description": "MIAPPE V1.1 (DM-9) Associated publication - An identifier for a literature publication where the investigation is described. Use of DOIs is recommended.",
+                    "type": "string"
+				},
+				"publicationPUI": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "publicationReference": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+				"trial": {
+					"description": "Publications associated with a trial",
+					"$ref": "../BrAPI-Core/Trial.json#/$defs/Trial",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "publications"
+				}
+			},
+			"required": [
+                "publicationsDbId"
+            ],
+            "title": "Publications",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+		}
     },
     "$id": "https://brapi.org/Specification/BrAPI-Schema/BrAPI-Core/Trial.json",
     "$schema": "http://json-schema.org/draft/2020-12/schema"

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/AlleleMatrix.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/AlleleMatrix.json
@@ -13,8 +13,8 @@
                 },
                 "dataMatrices": {
                     "description": "The 'dataMatrices' are an array of matrix objects that hold the allele data and associated metadata. Each matrix should be the same size and orientation, aligned with the \"callSetDbIds\" as columns and the \"variantDbIds\" as rows.",
-					"relationshipType": "one-to-many",
-					"referencedAttribute": "alleleMatrix",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "alleleMatrix",
                     "items": {
                         "$ref": "../BrAPI-Genotyping/AlleleMatrix.json#/$defs/DataMatrices",
                         "description": "DataMatrices"
@@ -34,8 +34,8 @@
                 },
                 "pagination": {
                     "description": "Pagination for the matrix",
-					"relationshipType": "one-to-many",
-					"referencedAttribute": "alleleMatrix",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "alleleMatrix",
                     "items": {
                         "$ref": "../BrAPI-Genotyping/AlleleMatrix.json#/$defs/Pagination",
                         "description": "Pagination"
@@ -97,12 +97,12 @@
             }
         },
         "DataMatrices": {
-			"properties": {
-				"dataMatricesDbId": {
+            "properties": {
+                "dataMatricesDbId": {
                     "description": "This is a single data matrix. It could be the allele matrix or an additional layer of metadata associated with each genotype value.",
                     "type": "string"
-				},
-				"dataMatrix": {
+                },
+                "dataMatrix": {
                     "description": "The two dimensional array of data, providing the allele matrix or an additional layer of metadata associated with each genotype value. Each matrix should be the same size and orientation, aligned with the \"callSetDbIds\" as columns and the \"variantDbIds\" as rows.",
                     "items": {
                         "description": "An array of rows in the data matrix",
@@ -145,14 +145,14 @@
                         "string"
                     ]
                 },
-				"alleleMatrix": {
-					"description": "Data matrices associated with an alleleMatrix",
-					"$ref": "../BrAPI-Genotyping/AlleleMatrix.json#/$defs/AlleleMatrix",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "dataMatrices"
-				}
-			},
-			"required": [
+                "alleleMatrix": {
+                    "description": "Data matrices associated with an alleleMatrix",
+                    "$ref": "../BrAPI-Genotyping/AlleleMatrix.json#/$defs/AlleleMatrix",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "dataMatrices"
+                }
+            },
+            "required": [
                 "dataMatricesDbId"
             ],
             "title": "DataMatrix",
@@ -160,14 +160,14 @@
             "brapi-metadata": {
                 "primaryModel": false
             }
-		},
+        },
         "Pagination": {
-			"properties": {
-				"paginationDbId": {
+            "properties": {
+                "paginationDbId": {
                     "description": "Pagination for the matrix",
                     "type": "string"
-				},
-				"dimension": {
+                },
+                "dimension": {
                     "description": "The dimension of the matrix being paginated",
                     "enum": [
                         "CALLSETS",
@@ -207,14 +207,14 @@
                         "integer"
                     ]
                 },
-				"alleleMatrix": {
-					"description": "Pgination associated with an alleleMatrix",
-					"$ref": "../BrAPI-Genotyping/AlleleMatrix.json#/$defs/AlleleMatrix",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "pagination"
-				}
-			},
-			"required": [
+                "alleleMatrix": {
+                    "description": "Pgination associated with an alleleMatrix",
+                    "$ref": "../BrAPI-Genotyping/AlleleMatrix.json#/$defs/AlleleMatrix",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "pagination"
+                }
+            },
+            "required": [
                 "paginationDbId"
             ],
             "title": "Pagination",
@@ -222,7 +222,7 @@
             "brapi-metadata": {
                 "primaryModel": false
             }
-		}
+        }
     },
     "$id": "https://brapi.org/Specification/BrAPI-Schema/BrAPI-Genotyping/AlleleMatrix.json",
     "$schema": "http://json-schema.org/draft/2020-12/schema"

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/AlleleMatrix.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/AlleleMatrix.json
@@ -13,56 +13,13 @@
                 },
                 "dataMatrices": {
                     "description": "The 'dataMatrices' are an array of matrix objects that hold the allele data and associated metadata. Each matrix should be the same size and orientation, aligned with the \"callSetDbIds\" as columns and the \"variantDbIds\" as rows.",
+					"relationshipType": "one-to-many",
+					"referencedAttribute": "alleleMatrix",
                     "items": {
-                        "description": "This is a single data matrix. It could be the allele matrix or an additional layer of metadata associated with each genotype value.",
-                        "title": "DataMatrix",
-                        "properties": {
-                            "dataMatrix": {
-                                "description": "The two dimensional array of data, providing the allele matrix or an additional layer of metadata associated with each genotype value. Each matrix should be the same size and orientation, aligned with the \"callSetDbIds\" as columns and the \"variantDbIds\" as rows.",
-                                "items": {
-                                    "description": "An array of rows in the data matrix",
-                                    "items": {
-                                        "description": "All the values per row (columns) in the data matrix",
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                "type": [
-                                    "null",
-                                    "array"
-                                ]
-                            },
-                            "dataMatrixAbbreviation": {
-                                "description": "The abbreviated code of the field represented in this data matrix. These codes should match the VCF standard when possible and the key word \"GT\" is reserved for the allele matrix. Examples of other metadata matrices include: \"GQ\", \"RD\", and \"HQ\"\n<br> This maps to a FORMAT field in the VCF file standard.",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "dataMatrixName": {
-                                "description": "The name of the field represented in this data matrix. The key word \"Genotype\" is reserved for the allele matrix. Examples of other metadata matrices include: \"Genotype Quality\", \"Read Depth\", and \"Haplotype Quality\"\n<br> This maps to a FORMAT field in the VCF file standard.",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "dataType": {
-                                "description": "The type of field represented in this data matrix. This is intended to help parse the data out of JSON.",
-                                "enum": [
-                                    "string",
-                                    "integer",
-                                    "float",
-                                    "boolean",
-                                    null
-                                ],
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "../BrAPI-Genotyping/AlleleMatrix.json#/$defs/DataMatrices",
+                        "description": "DataMatrices"
                     },
+                    "title": "DataMatrices",
                     "type": [
                         "null",
                         "array"
@@ -77,52 +34,13 @@
                 },
                 "pagination": {
                     "description": "Pagination for the matrix",
-                    "title": "MatrixPage",
+					"relationshipType": "one-to-many",
+					"referencedAttribute": "alleleMatrix",
                     "items": {
-                        "properties": {
-                            "dimension": {
-                                "description": "The dimension of the matrix being paginated",
-                                "enum": [
-                                    "CALLSETS",
-                                    "VARIANTS",
-                                    null
-                                ],
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "page": {
-                                "description": "the requested page number (zero indexed)",
-                                "type": [
-                                    "null",
-                                    "integer"
-                                ]
-                            },
-                            "pageSize": {
-                                "description": "the maximum number of elements per page in this dimension of the matrix",
-                                "type": [
-                                    "null",
-                                    "integer"
-                                ]
-                            },
-                            "totalCount": {
-                                "description": "The total number of elements that are available on the server and match the requested query parameters.",
-                                "type": [
-                                    "null",
-                                    "integer"
-                                ]
-                            },
-                            "totalPages": {
-                                "description": "The total number of pages of elements available on the server. This should be calculated with the following formula. \n<br/>totalPages = CEILING( totalCount / requested_page_size)",
-                                "type": [
-                                    "null",
-                                    "integer"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "../BrAPI-Genotyping/AlleleMatrix.json#/$defs/Pagination",
+                        "description": "Pagination"
                     },
+                    "title": "Pagination",
                     "type": [
                         "null",
                         "array"
@@ -177,7 +95,134 @@
             "brapi-metadata": {
                 "primaryModel": true
             }
-        }
+        },
+        "DataMatrices": {
+			"properties": {
+				"dataMatricesDbId": {
+                    "description": "This is a single data matrix. It could be the allele matrix or an additional layer of metadata associated with each genotype value.",
+                    "type": "string"
+				},
+				"dataMatrix": {
+                    "description": "The two dimensional array of data, providing the allele matrix or an additional layer of metadata associated with each genotype value. Each matrix should be the same size and orientation, aligned with the \"callSetDbIds\" as columns and the \"variantDbIds\" as rows.",
+                    "items": {
+                        "description": "An array of rows in the data matrix",
+                        "items": {
+                            "description": "All the values per row (columns) in the data matrix",
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "dataMatrixAbbreviation": {
+                    "description": "The abbreviated code of the field represented in this data matrix. These codes should match the VCF standard when possible and the key word \"GT\" is reserved for the allele matrix. Examples of other metadata matrices include: \"GQ\", \"RD\", and \"HQ\"\n<br> This maps to a FORMAT field in the VCF file standard.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "dataMatrixName": {
+                    "description": "The name of the field represented in this data matrix. The key word \"Genotype\" is reserved for the allele matrix. Examples of other metadata matrices include: \"Genotype Quality\", \"Read Depth\", and \"Haplotype Quality\"\n<br> This maps to a FORMAT field in the VCF file standard.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "dataType": {
+                    "description": "The type of field represented in this data matrix. This is intended to help parse the data out of JSON.",
+                    "enum": [
+                        "string",
+                        "integer",
+                        "float",
+                        "boolean",
+                        null
+                    ],
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+				"alleleMatrix": {
+					"description": "Data matrices associated with an alleleMatrix",
+					"$ref": "../BrAPI-Genotyping/AlleleMatrix.json#/$defs/AlleleMatrix",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "dataMatrices"
+				}
+			},
+			"required": [
+                "dataMatricesDbId"
+            ],
+            "title": "DataMatrix",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+		},
+        "Pagination": {
+			"properties": {
+				"paginationDbId": {
+                    "description": "Pagination for the matrix",
+                    "type": "string"
+				},
+				"dimension": {
+                    "description": "The dimension of the matrix being paginated",
+                    "enum": [
+                        "CALLSETS",
+                        "VARIANTS",
+                        null
+                    ],
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "page": {
+                    "description": "the requested page number (zero indexed)",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "pageSize": {
+                    "description": "the maximum number of elements per page in this dimension of the matrix",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "totalCount": {
+                    "description": "The total number of elements that are available on the server and match the requested query parameters.",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "totalPages": {
+                    "description": "The total number of pages of elements available on the server. This should be calculated with the following formula. \n<br/>totalPages = CEILING( totalCount / requested_page_size)",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+				"alleleMatrix": {
+					"description": "Pgination associated with an alleleMatrix",
+					"$ref": "../BrAPI-Genotyping/AlleleMatrix.json#/$defs/AlleleMatrix",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "pagination"
+				}
+			},
+			"required": [
+                "paginationDbId"
+            ],
+            "title": "Pagination",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+		}
     },
     "$id": "https://brapi.org/Specification/BrAPI-Schema/BrAPI-Genotyping/AlleleMatrix.json",
     "$schema": "http://json-schema.org/draft/2020-12/schema"

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/AlleleMatrix.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/AlleleMatrix.json
@@ -2,13 +2,6 @@
     "$defs": {
         "AlleleMatrix": {
             "properties": {
-				"alleleMatrixDbId": {
-                    "description": "The ID which uniquely identifies a allele matrix",
-                    "type": [
-                        "null",
-                        "string"
-                    ]
-                },
                 "callSets": {
                     "description": "A list of unique identifiers for the CallSets contained in the matrix response. This array should match the ordering for columns in the matrix. A CallSet is a unique combination of a Sample and a sequencing event. CallSets often have a 1-to-1 relationship with Samples, but this is not always the case.",
                     "items": {

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/AlleleMatrix.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/AlleleMatrix.json
@@ -2,6 +2,13 @@
     "$defs": {
         "AlleleMatrix": {
             "properties": {
+				"alleleMatrixDbId": {
+                    "description": "The ID which uniquely identifies a allele matrix",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
                 "callSets": {
                     "description": "A list of unique identifiers for the CallSets contained in the matrix response. This array should match the ordering for columns in the matrix. A CallSet is a unique combination of a Sample and a sequencing event. CallSets often have a 1-to-1 relationship with Samples, but this is not always the case.",
                     "items": {

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/Call.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/Call.json
@@ -7,13 +7,6 @@
                     "relationshipType": "one-to-one",
                     "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
                 },
-				"callDbId": {
-                    "description": "The ID which uniquely identifies a call",
-                    "type": [
-                        "null",
-                        "string"
-                    ]
-                },
                 "callSet": {
                     "$ref": "CallSet.json#/$defs/CallSet",
                     "description": "The ID of the call set this variant call belongs to.\n\nIf this field is not present, the ordering of the call sets from a `SearchCallSetsRequest` over this `VariantSet` is guaranteed to match the ordering of the calls on this `Variant`. The number of results will also be the same.",

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/Call.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/Call.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "callSet": {
                     "$ref": "CallSet.json#/$defs/CallSet",
@@ -14,46 +22,13 @@
                 },
                 "genotypeMetadata": {
                     "description": "Genotype Metadata are additional layers of metadata associated with each genotype.",
+					"relationshipType": "one-to-many",
+					"referencedAttribute": "call",
                     "items": {
-                        "properties": {
-                            "dataType": {
-                                "description": "The type of field represented in this Genotype Field. This is intended to help parse the data out of JSON.",
-                                "enum": [
-                                    "string",
-                                    "integer",
-                                    "float",
-                                    "boolean",
-                                    null
-                                ],
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "fieldAbbreviation": {
-                                "description": "The abbreviated code of the field represented in this Genotype Field. These codes should match the VCF standard when possible. Examples include: \"GQ\", \"RD\", and \"HQ\"\n<br> This maps to a FORMAT field in the VCF file standard.",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "fieldName": {
-                                "description": "The name of the field represented in this Genotype Field. Examples include: \"Genotype Quality\", \"Read Depth\", and \"Haplotype Quality\"\n<br> This maps to a FORMAT field in the VCF file standard.",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "fieldValue": {
-                                "description": "The additional metadata value associated with this genotype call",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "../BrAPI-Genotyping/Call.json#/$defs/GenotypeMetadata",
+                        "description": "GenotypeMetadata"
                     },
+                    "title": "GenotypeMetadata",
                     "type": [
                         "null",
                         "array"
@@ -96,7 +71,64 @@
             "brapi-metadata": {
                 "primaryModel": true
             }
-        }
+        },
+        "GenotypeMetadata": {
+			"properties": {
+				"genotypeMetadataDbId": {
+                    "description": "MIAPPE V1.1 (DM-9) Associated publication - An identifier for a literature publication where the investigation is described. Use of DOIs is recommended.",
+                    "type": "string"
+				},
+				"dataType": {
+                    "description": "The type of field represented in this Genotype Field. This is intended to help parse the data out of JSON.",
+                    "enum": [
+                        "string",
+                        "integer",
+                        "float",
+                        "boolean",
+                        null
+                    ],
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "fieldAbbreviation": {
+                    "description": "The abbreviated code of the field represented in this Genotype Field. These codes should match the VCF standard when possible. Examples include: \"GQ\", \"RD\", and \"HQ\"\n<br> This maps to a FORMAT field in the VCF file standard.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "fieldName": {
+                    "description": "The name of the field represented in this Genotype Field. Examples include: \"Genotype Quality\", \"Read Depth\", and \"Haplotype Quality\"\n<br> This maps to a FORMAT field in the VCF file standard.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "fieldValue": {
+                    "description": "The additional metadata value associated with this genotype call",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+				"call": {
+					"description": "Genotype metadata associated with a call",
+					"$ref": "../BrAPI-Genotyping/Call.json#/$defs/Call",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "genotypeMetadata"
+				}
+			},
+			"required": [
+                "genotypeMetadataDbId"
+            ],
+            "title": "GenotypeMetadata",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+		}
     },
     "$id": "https://brapi.org/Specification/BrAPI-Schema/BrAPI-Genotyping/Call.json",
     "$schema": "http://json-schema.org/draft/2020-12/schema"

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/Call.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/Call.json
@@ -22,8 +22,8 @@
                 },
                 "genotypeMetadata": {
                     "description": "Genotype Metadata are additional layers of metadata associated with each genotype.",
-					"relationshipType": "one-to-many",
-					"referencedAttribute": "call",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "call",
                     "items": {
                         "$ref": "../BrAPI-Genotyping/Call.json#/$defs/GenotypeMetadata",
                         "description": "GenotypeMetadata"
@@ -73,12 +73,12 @@
             }
         },
         "GenotypeMetadata": {
-			"properties": {
-				"genotypeMetadataDbId": {
+            "properties": {
+                "genotypeMetadataDbId": {
                     "description": "MIAPPE V1.1 (DM-9) Associated publication - An identifier for a literature publication where the investigation is described. Use of DOIs is recommended.",
                     "type": "string"
-				},
-				"dataType": {
+                },
+                "dataType": {
                     "description": "The type of field represented in this Genotype Field. This is intended to help parse the data out of JSON.",
                     "enum": [
                         "string",
@@ -113,14 +113,14 @@
                         "string"
                     ]
                 },
-				"call": {
-					"description": "Genotype metadata associated with a call",
-					"$ref": "../BrAPI-Genotyping/Call.json#/$defs/Call",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "genotypeMetadata"
-				}
-			},
-			"required": [
+                "call": {
+                    "description": "Genotype metadata associated with a call",
+                    "$ref": "../BrAPI-Genotyping/Call.json#/$defs/Call",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "genotypeMetadata"
+                }
+            },
+            "required": [
                 "genotypeMetadataDbId"
             ],
             "title": "GenotypeMetadata",
@@ -128,7 +128,7 @@
             "brapi-metadata": {
                 "primaryModel": false
             }
-		}
+        }
     },
     "$id": "https://brapi.org/Specification/BrAPI-Schema/BrAPI-Genotyping/Call.json",
     "$schema": "http://json-schema.org/draft/2020-12/schema"

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/Call.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/Call.json
@@ -4,14 +4,14 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
+                    "relationshipType": "one-to-one",
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                },
+				"callDbId": {
+                    "description": "The ID which uniquely identifies a call",
                     "type": [
                         "null",
-                        "array"
+                        "string"
                     ]
                 },
                 "callSet": {

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/CallSet.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/CallSet.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "alleleMatrices": {
                     "title": "AlleleMatrices",
@@ -55,8 +63,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/CallSet.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/CallSet.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "alleleMatrices": {
                     "title": "AlleleMatrices",

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/GenomeMap.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/GenomeMap.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "markerPositions": {
                     "title": "markerPositions",

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/GenomeMap.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/GenomeMap.json
@@ -47,7 +47,7 @@
                         "integer"
                     ]
                 },
-                "genomeMapDbId": {
+                "mapDbId": {
                     "description": "The unique identifier for a `GenomeMap`",
                     "type": [
                         "null",
@@ -103,7 +103,7 @@
                 }
             },
             "required": [
-                "genomeMapDbId",
+                "mapDbId",
                 "commonCropName",
                 "type"
             ],

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/GenomeMap.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/GenomeMap.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "relationshipType": "one-to-one",
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
                 },
                 "markerPositions": {
                     "title": "markerPositions",
@@ -54,7 +47,7 @@
                         "integer"
                     ]
                 },
-                "mapDbId": {
+                "genomeMapDbId": {
                     "description": "The unique identifier for a `GenomeMap`",
                     "type": [
                         "null",
@@ -110,7 +103,7 @@
                 }
             },
             "required": [
-                "mapDbId",
+                "genomeMapDbId",
                 "commonCropName",
                 "type"
             ],

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/MarkerPosition.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/MarkerPosition.json
@@ -4,14 +4,14 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
+                    "relationshipType": "one-to-one",
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                },
+				"markerPositionDbId": {
+                    "description": "The ID which uniquely identifies a marker position",
                     "type": [
                         "null",
-                        "array"
+                        "string"
                     ]
                 },
                 "linkageGroupName": {

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/MarkerPosition.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/MarkerPosition.json
@@ -7,14 +7,7 @@
                     "relationshipType": "one-to-one",
                     "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
                 },
-				"markerPositionDbId": {
-                    "description": "The ID which uniquely identifies a marker position",
-                    "type": [
-                        "null",
-                        "string"
-                    ]
-                },
-                "linkageGroupName": {
+				"linkageGroupName": {
                     "description": "The Uniquely Identifiable name of a `LinkageGroup`\n<br> This might be a chromosome identifier or the generic linkage group identifier if the chromosome is not applicable.",
                     "type": [
                         "null",

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/MarkerPosition.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/MarkerPosition.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "linkageGroupName": {
                     "description": "The Uniquely Identifiable name of a `LinkageGroup`\n<br> This might be a chromosome identifier or the generic linkage group identifier if the chromosome is not applicable.",

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/Plate.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/Plate.json
@@ -4,12 +4,22 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/Plate.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/Plate.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/Reference.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/Reference.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "commonCropName": {
                     "description": "Common name for the crop",
@@ -15,8 +23,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [
@@ -78,25 +88,13 @@
                 },
                 "sourceGermplasm": {
                     "description": "All known corresponding Germplasm",
+					"relationshipType": "one-to-many",
+					"referencedAttribute": "reference",
                     "items": {
-                        "properties": {
-                            "germplasmDbId": {
-                                "description": "The ID which uniquely identifies a `Germplasm` within the given database server",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "germplasmName": {
-                                "description": "The human readable name of a `Germplasm`",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "../BrAPI-Common/SourceGermplasm.json#/$defs/SourceGermplasm",
+                        "description": "SourceGermplasm"
                     },
+                    "title": "SourceGermplasm",
                     "type": [
                         "null",
                         "array"
@@ -111,26 +109,16 @@
                 },
                 "species": {
                     "description": "An ontology term describing an attribute.",
-                    "title": "OntologyTerm",
-                    "properties": {
-                        "term": {
-                            "description": "Ontology term - the label of the ontology term the termId is pointing to.",
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        },
-                        "termURI": {
-                            "description": "Ontology term identifier - the CURIE for an ontology term. It differs from the standard GA4GH schema's :ref:`id ` in that it is a CURIE pointing to an information resource outside of the scope of the schema or its resource implementation.",
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        }
+					"relationshipType": "one-to-many",
+					"referencedAttribute": "reference",
+                    "items": {
+                        "$ref": "../BrAPI-Common/Species.json#/$defs/Species",
+                        "description": "Species"
                     },
+                    "title": "OntologyTerm",
                     "type": [
                         "null",
-                        "object"
+                        "array"
                     ]
                 },
                 "variants": {
@@ -158,6 +146,8 @@
                 "primaryModel": true
             }
         }
+        
+       
     },
     "$id": "https://brapi.org/Specification/BrAPI-Schema/BrAPI-Genotyping/Reference.json",
     "$schema": "http://json-schema.org/draft/2020-12/schema"

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/Reference.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/Reference.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "commonCropName": {
                     "description": "Common name for the crop",
@@ -109,17 +102,9 @@
                 },
                 "species": {
                     "description": "An ontology term describing an attribute.",
-                    "relationshipType": "one-to-many",
+                    "relationshipType": "one-to-one",
                     "referencedAttribute": "reference",
-                    "items": {
-                        "$ref": "../BrAPI-Common/Species.json#/$defs/Species",
-                        "description": "Species"
-                    },
-                    "title": "OntologyTerm",
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+					"$ref": "../BrAPI-Common/Species.json#/$defs/Species"
                 },
                 "variants": {
                     "title": "variants",

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/Reference.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/Reference.json
@@ -88,8 +88,8 @@
                 },
                 "sourceGermplasm": {
                     "description": "All known corresponding Germplasm",
-					"relationshipType": "one-to-many",
-					"referencedAttribute": "reference",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "reference",
                     "items": {
                         "$ref": "../BrAPI-Common/SourceGermplasm.json#/$defs/SourceGermplasm",
                         "description": "SourceGermplasm"
@@ -109,8 +109,8 @@
                 },
                 "species": {
                     "description": "An ontology term describing an attribute.",
-					"relationshipType": "one-to-many",
-					"referencedAttribute": "reference",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "reference",
                     "items": {
                         "$ref": "../BrAPI-Common/Species.json#/$defs/Species",
                         "description": "Species"
@@ -146,8 +146,6 @@
                 "primaryModel": true
             }
         }
-        
-       
     },
     "$id": "https://brapi.org/Specification/BrAPI-Schema/BrAPI-Genotyping/Reference.json",
     "$schema": "http://json-schema.org/draft/2020-12/schema"

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/ReferenceSet.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/ReferenceSet.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "assemblyPUI": {
                     "description": "The remaining information is about the source of the sequences Public id of this reference set, such as `GRCH_37`.",
@@ -29,8 +37,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [
@@ -72,25 +82,13 @@
                 },
                 "sourceGermplasm": {
                     "description": "All known corresponding Germplasm",
+					"relationshipType": "one-to-many",
+					"referencedAttribute": "referenceSet",
                     "items": {
-                        "properties": {
-                            "germplasmDbId": {
-                                "description": "The ID which uniquely identifies a germplasm within the given database server",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "germplasmName": {
-                                "description": "The human readable name of a germplasm",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "../BrAPI-Common/SourceGermplasm.json#/$defs/SourceGermplasm",
+                        "description": "SourceGermplasm"
                     },
+                    "title": "SourceGermplasm",
                     "type": [
                         "null",
                         "array"
@@ -105,25 +103,16 @@
                 },
                 "species": {
                     "description": "An ontology term describing an attribute.",
-                    "properties": {
-                        "term": {
-                            "description": "Ontology term - the label of the ontology term the termId is pointing to.",
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        },
-                        "termURI": {
-                            "description": "Ontology term identifier - the CURIE for an ontology term. It differs from the standard GA4GH schema's :ref:`id ` in that it is a CURIE pointing to an information resource outside of the scope of the schema or its resource implementation.",
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        }
+					"relationshipType": "one-to-many",
+					"referencedAttribute": "referenceSet",
+                    "items": {
+                        "$ref": "../BrAPI-Common/Species.json#/$defs/Species",
+                        "description": "Species"
                     },
+                    "title": "Species",
                     "type": [
                         "null",
-                        "object"
+                        "array"
                     ]
                 },
                 "references": {

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/ReferenceSet.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/ReferenceSet.json
@@ -82,8 +82,8 @@
                 },
                 "sourceGermplasm": {
                     "description": "All known corresponding Germplasm",
-					"relationshipType": "one-to-many",
-					"referencedAttribute": "referenceSet",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "referenceSet",
                     "items": {
                         "$ref": "../BrAPI-Common/SourceGermplasm.json#/$defs/SourceGermplasm",
                         "description": "SourceGermplasm"
@@ -103,8 +103,8 @@
                 },
                 "species": {
                     "description": "An ontology term describing an attribute.",
-					"relationshipType": "one-to-many",
-					"referencedAttribute": "referenceSet",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "referenceSet",
                     "items": {
                         "$ref": "../BrAPI-Common/Species.json#/$defs/Species",
                         "description": "Species"

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/ReferenceSet.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/ReferenceSet.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "assemblyPUI": {
                     "description": "The remaining information is about the source of the sequences Public id of this reference set, such as `GRCH_37`.",
@@ -101,33 +94,18 @@
                         "string"
                     ]
                 },
-                "species": {
+				"species": {
                     "description": "An ontology term describing an attribute.",
-                    "relationshipType": "one-to-many",
+                    "relationshipType": "one-to-one",
                     "referencedAttribute": "referenceSet",
-                    "items": {
-                        "$ref": "../BrAPI-Common/Species.json#/$defs/Species",
-                        "description": "Species"
-                    },
-                    "title": "Species",
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+					"$ref": "../BrAPI-Common/Species.json#/$defs/Species"
                 },
                 "references": {
                     "title": "references",
                     "description": "references",
                     "referencedAttribute": "referenceSet",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "Reference.json#/$defs/Reference",
-                        "description": "Reference"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "relationshipType": "one-to-one",
+					"$ref": "Reference.json#/$defs/Reference"
                 },
                 "variants": {
                     "title": "variants",

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/Sample.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/Sample.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "callSets": {
                     "title": "CallSets",
@@ -31,8 +39,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/Sample.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/Sample.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "callSets": {
                     "title": "CallSets",

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/Variant.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/Variant.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "markerPositions": {
                     "title": "markerPositions",
@@ -95,8 +103,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/Variant.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/Variant.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "markerPositions": {
                     "title": "markerPositions",

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/VariantSet.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/VariantSet.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "alleleMatrices": {
                     "title": "AlleleMatrices",
@@ -70,19 +63,11 @@
                         "array"
                     ]
                 },
-                "availableFormats": {
+                "availableFormat": {
                     "description": "When the data for a VariantSet is retrieved, it can be retrieved in a variety of data formats and file formats. \n<br/>'dataFormat' defines the structure of the data within a file (ie DartSeq, VCF, Hapmap, tabular, etc)\n<br/>'fileFormat' defines the MIME type of the file (ie text/csv, application/excel, application/zip). This should also be reflected in the Accept and ContentType HTTP headers for every relevant request and response.",
-                    "relationshipType": "one-to-many",
+                    "relationshipType": "one-to-one",
                     "referencedAttribute": "variantSet",
-                    "items": {
-                        "$ref": "../BrAPI-Genotyping/VariantSet.json#/$defs/AvailableFormats",
-                        "description": "AvailableFormats"
-                    },
-                    "title": "AvailableFormats",
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+					"$ref": "../BrAPI-Genotyping/VariantSet.json#/$defs/AvailableFormat"
                 },
                 "callSetCount": {
                     "description": "The number of CallSets included in this VariantSet",
@@ -104,19 +89,11 @@
                         "array"
                     ]
                 },
-                "metadataFields": {
-                    "description": "The 'metadataFields' array indicates which types of genotyping data and metadata are available in the VariantSet. \n<br> When possible, these field names and abbreviations should follow the VCF standard ",
-                    "relationshipType": "one-to-many",
+                "metadataField": {
+                    "description": "The 'metadataField' indicates which types of genotyping data and metadata are available in the VariantSet. \n<br> When possible, these field names and abbreviations should follow the VCF standard ",
+                    "relationshipType": "one-to-one",
                     "referencedAttribute": "variantSet",
-                    "items": {
-                        "$ref": "../BrAPI-Genotyping/VariantSet.json#/$defs/MetadataFields",
-                        "description": "MetadataFields"
-                    },
-                    "title": "MetadataFields",
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+					"$ref": "../BrAPI-Genotyping/VariantSet.json#/$defs/MetadataField"
                 },
                 "referenceSet": {
                     "$ref": "ReferenceSet.json#/$defs/ReferenceSet",
@@ -244,9 +221,9 @@
                 "primaryModel": false
             }
         },
-        "AvailableFormats": {
+        "AvailableFormat": {
             "properties": {
-                "formatDbId": {
+                "availableFormatDbId": {
                     "description": "When the data for a VariantSet is retrieved, it can be retrieved in a variety of data formats and file formats. \n<br/>'dataFormat' defines the structure of the data within a file (ie DartSeq, VCF, Hapmap, tabular, etc)\n<br/>'fileFormat' defines the MIME type of the file (ie text/csv, application/excel, application/zip). This should also be reflected in the Accept and ContentType HTTP headers for every relevant request and response.",
                     "type": [
                         "null",
@@ -327,7 +304,7 @@
                 }
             },
             "required": [
-                "formatDbId"
+                "availableFormatDbId"
             ],
             "title": "AvailableFormats",
             "type": "object",
@@ -335,7 +312,7 @@
                 "primaryModel": false
             }
         },
-        "MetadataFields": {
+        "MetadataField": {
             "properties": {
                 "metadataFieldDbId": {
                     "description": "This represents a type of genotyping data or metadata available in this VariantSet",

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/VariantSet.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/VariantSet.json
@@ -223,13 +223,6 @@
         },
         "AvailableFormat": {
             "properties": {
-                "availableFormatDbId": {
-                    "description": "When the data for a VariantSet is retrieved, it can be retrieved in a variety of data formats and file formats. \n<br/>'dataFormat' defines the structure of the data within a file (ie DartSeq, VCF, Hapmap, tabular, etc)\n<br/>'fileFormat' defines the MIME type of the file (ie text/csv, application/excel, application/zip). This should also be reflected in the Accept and ContentType HTTP headers for every relevant request and response.",
-                    "type": [
-                        "null",
-                        "string"
-                    ]
-                },
                 "dataFormat": {
                     "description": "dataFormat defines the structure of the data within a file (ie DartSeq, VCF, Hapmap, tabular, etc)",
                     "enum": [
@@ -303,9 +296,6 @@
                     "referencedAttribute": "availableFormats"
                 }
             },
-            "required": [
-                "availableFormatDbId"
-            ],
             "title": "AvailableFormats",
             "type": "object",
             "brapi-metadata": {

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/VariantSet.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/VariantSet.json
@@ -58,8 +58,8 @@
                 },
                 "analysis": {
                     "description": "Set of Analysis descriptors for this VariantSet",
-					"relationshipType": "one-to-many",
-					"referencedAttribute": "variantSet",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "variantSet",
                     "items": {
                         "$ref": "../BrAPI-Genotyping/VariantSet.json#/$defs/Analysis",
                         "description": "Analysis"
@@ -72,8 +72,8 @@
                 },
                 "availableFormats": {
                     "description": "When the data for a VariantSet is retrieved, it can be retrieved in a variety of data formats and file formats. \n<br/>'dataFormat' defines the structure of the data within a file (ie DartSeq, VCF, Hapmap, tabular, etc)\n<br/>'fileFormat' defines the MIME type of the file (ie text/csv, application/excel, application/zip). This should also be reflected in the Accept and ContentType HTTP headers for every relevant request and response.",
-					"relationshipType": "one-to-many",
-					"referencedAttribute": "variantSet",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "variantSet",
                     "items": {
                         "$ref": "../BrAPI-Genotyping/VariantSet.json#/$defs/AvailableFormats",
                         "description": "AvailableFormats"
@@ -106,8 +106,8 @@
                 },
                 "metadataFields": {
                     "description": "The 'metadataFields' array indicates which types of genotyping data and metadata are available in the VariantSet. \n<br> When possible, these field names and abbreviations should follow the VCF standard ",
-					"relationshipType": "one-to-many",
-					"referencedAttribute": "variantSet",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "variantSet",
                     "items": {
                         "$ref": "../BrAPI-Genotyping/VariantSet.json#/$defs/MetadataFields",
                         "description": "MetadataFields"
@@ -173,8 +173,8 @@
             }
         },
         "Analysis": {
-			"properties": {
-				"analysisDbId": {
+            "properties": {
+                "analysisDbId": {
                     "description": "Unique identifier for this analysis description",
                     "type": [
                         "null",
@@ -229,13 +229,13 @@
                     ]
                 },
                 "variantSet": {
-					"description": "Analysis associated with a variant set",
-					"$ref": "../BrAPI-Genotyping/VariantSet.json#/$defs/VariantSet",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "analysis"
-				}
-			},
-			"required": [
+                    "description": "Analysis associated with a variant set",
+                    "$ref": "../BrAPI-Genotyping/VariantSet.json#/$defs/VariantSet",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "analysis"
+                }
+            },
+            "required": [
                 "analysisDbId"
             ],
             "title": "Analysis",
@@ -243,10 +243,10 @@
             "brapi-metadata": {
                 "primaryModel": false
             }
-		},
+        },
         "AvailableFormats": {
-			"properties": {
-				"formatDbId": {
+            "properties": {
+                "formatDbId": {
                     "description": "When the data for a VariantSet is retrieved, it can be retrieved in a variety of data formats and file formats. \n<br/>'dataFormat' defines the structure of the data within a file (ie DartSeq, VCF, Hapmap, tabular, etc)\n<br/>'fileFormat' defines the MIME type of the file (ie text/csv, application/excel, application/zip). This should also be reflected in the Accept and ContentType HTTP headers for every relevant request and response.",
                     "type": [
                         "null",
@@ -320,13 +320,13 @@
                     ]
                 },
                 "variantSet": {
-					"description": "Formats associated with a variant set",
-					"$ref": "../BrAPI-Genotyping/VariantSet.json#/$defs/VariantSet",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "availableFormats"
-				}
-			},
-			"required": [
+                    "description": "Formats associated with a variant set",
+                    "$ref": "../BrAPI-Genotyping/VariantSet.json#/$defs/VariantSet",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "availableFormats"
+                }
+            },
+            "required": [
                 "formatDbId"
             ],
             "title": "AvailableFormats",
@@ -334,10 +334,10 @@
             "brapi-metadata": {
                 "primaryModel": false
             }
-		},
+        },
         "MetadataFields": {
-			"properties": {
-				"metadataFieldDbId": {
+            "properties": {
+                "metadataFieldDbId": {
                     "description": "This represents a type of genotyping data or metadata available in this VariantSet",
                     "type": [
                         "null",
@@ -373,13 +373,13 @@
                     ]
                 },
                 "variantSet": {
-					"description": "Formats associated with a variant set",
-					"$ref": "../BrAPI-Genotyping/VariantSet.json#/$defs/VariantSet",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "metadataFields"
-				}
-			},
-			"required": [
+                    "description": "Formats associated with a variant set",
+                    "$ref": "../BrAPI-Genotyping/VariantSet.json#/$defs/VariantSet",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "metadataFields"
+                }
+            },
+            "required": [
                 "metadataFieldDbId"
             ],
             "title": "MetadataFields",
@@ -387,8 +387,7 @@
             "brapi-metadata": {
                 "primaryModel": false
             }
-		}
-
+        }
     },
     "$id": "https://brapi.org/Specification/BrAPI-Schema/BrAPI-Genotyping/VariantSet.json",
     "$schema": "http://json-schema.org/draft/2020-12/schema"

--- a/Specification/BrAPI-Schema/BrAPI-Genotyping/VariantSet.json
+++ b/Specification/BrAPI-Schema/BrAPI-Genotyping/VariantSet.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "alleleMatrices": {
                     "title": "AlleleMatrices",
@@ -50,67 +58,13 @@
                 },
                 "analysis": {
                     "description": "Set of Analysis descriptors for this VariantSet",
+					"relationshipType": "one-to-many",
+					"referencedAttribute": "variantSet",
                     "items": {
-                        "description": "An analysis contains an interpretation of one or several experiments. (e.g. SNVs, copy number variations, methylation status) together with information about the methodology used.",
-                        "title": "Analysis",
-                        "properties": {
-                            "analysisDbId": {
-                                "description": "Unique identifier for this analysis description",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "analysisName": {
-                                "description": "A human readable name for this analysis",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "created": {
-                                "description": "The time at which this record was created, in ISO 8601 format.",
-                                "format": "date-time",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "description": {
-                                "description": "A human readable description of the analysis",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "software": {
-                                "description": "The software run to generate this analysis.",
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": [
-                                    "null",
-                                    "array"
-                                ]
-                            },
-                            "type": {
-                                "description": "The type of analysis.",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "updated": {
-                                "description": "The time at which this record was last updated, in ISO 8601 format.",
-                                "format": "date-time",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "../BrAPI-Genotyping/VariantSet.json#/$defs/Analysis",
+                        "description": "Analysis"
                     },
+                    "title": "Analysis",
                     "type": [
                         "null",
                         "array"
@@ -118,78 +72,13 @@
                 },
                 "availableFormats": {
                     "description": "When the data for a VariantSet is retrieved, it can be retrieved in a variety of data formats and file formats. \n<br/>'dataFormat' defines the structure of the data within a file (ie DartSeq, VCF, Hapmap, tabular, etc)\n<br/>'fileFormat' defines the MIME type of the file (ie text/csv, application/excel, application/zip). This should also be reflected in the Accept and ContentType HTTP headers for every relevant request and response.",
+					"relationshipType": "one-to-many",
+					"referencedAttribute": "variantSet",
                     "items": {
-                        "description": "Each 'availableFormat' object is a pairing of dataFormat and fileFormat. These must be communicated in pairs because they are not independent parameters and sometimes one influences the other.",
-                        "properties": {
-                            "dataFormat": {
-                                "description": "dataFormat defines the structure of the data within a file (ie DartSeq, VCF, Hapmap, tabular, etc)",
-                                "enum": [
-                                    "DartSeq",
-                                    "VCF",
-                                    "Hapmap",
-                                    "tabular",
-                                    "JSON",
-                                    null
-                                ],
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "expandHomozygotes": {
-                                "description": "Should homozygotes be expanded (true) or collapsed into a single occurrence (false)",
-                                "type": [
-                                    "null",
-                                    "boolean"
-                                ]
-                            },
-                            "fileFormat": {
-                                "description": "fileFormat defines the MIME type of the file (ie text/csv, application/excel, application/zip). This should also be reflected in the Accept and ContentType HTTP headers for every relevant request and response.",
-                                "enum": [
-                                    "text/csv",
-                                    "text/tsv",
-                                    "application/excel",
-                                    "application/zip",
-                                    "application/json",
-                                    null
-                                ],
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "fileURL": {
-                                "description": "A URL which indicates the location of the file version of this VariantSet. Could be a static file URL or an API endpoint which generates the file.",
-                                "format": "uri",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "sepPhased": {
-                                "description": "The string used as a separator for phased allele calls.",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "sepUnphased": {
-                                "description": "The string used as a separator for unphased allele calls.",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "unknownString": {
-                                "description": "The string used as a representation for missing data.",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "../BrAPI-Genotyping/VariantSet.json#/$defs/AvailableFormats",
+                        "description": "AvailableFormats"
                     },
+                    "title": "AvailableFormats",
                     "type": [
                         "null",
                         "array"
@@ -204,8 +93,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [
@@ -215,40 +106,13 @@
                 },
                 "metadataFields": {
                     "description": "The 'metadataFields' array indicates which types of genotyping data and metadata are available in the VariantSet. \n<br> When possible, these field names and abbreviations should follow the VCF standard ",
+					"relationshipType": "one-to-many",
+					"referencedAttribute": "variantSet",
                     "items": {
-                        "description": "This represents a type of genotyping data or metadata available in this VariantSet",
-                        "properties": {
-                            "dataType": {
-                                "description": "The type of field represented in this Genotype Field. This is intended to help parse the data out of JSON.",
-                                "enum": [
-                                    "string",
-                                    "integer",
-                                    "float",
-                                    "boolean",
-                                    null
-                                ],
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "fieldAbbreviation": {
-                                "description": "The abbreviated code of the field represented in this Genotype Field. These codes should match the VCF standard when possible. Examples include: \"GQ\", \"RD\", and \"HQ\"",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "fieldName": {
-                                "description": "The name of the field represented in this Genotype Field. Examples include: \"Genotype Quality\", \"Read Depth\", and \"Haplotype Quality\"",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "../BrAPI-Genotyping/VariantSet.json#/$defs/MetadataFields",
+                        "description": "MetadataFields"
                     },
+                    "title": "MetadataFields",
                     "type": [
                         "null",
                         "array"
@@ -307,7 +171,224 @@
             "brapi-metadata": {
                 "primaryModel": true
             }
-        }
+        },
+        "Analysis": {
+			"properties": {
+				"analysisDbId": {
+                    "description": "Unique identifier for this analysis description",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "analysisName": {
+                    "description": "A human readable name for this analysis",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "created": {
+                    "description": "The time at which this record was created, in ISO 8601 format.",
+                    "format": "date-time",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "description": {
+                    "description": "A human readable description of the analysis",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "software": {
+                    "description": "The software run to generate this analysis.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "type": {
+                    "description": "The type of analysis.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "updated": {
+                    "description": "The time at which this record was last updated, in ISO 8601 format.",
+                    "format": "date-time",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "variantSet": {
+					"description": "Analysis associated with a variant set",
+					"$ref": "../BrAPI-Genotyping/VariantSet.json#/$defs/VariantSet",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "analysis"
+				}
+			},
+			"required": [
+                "analysisDbId"
+            ],
+            "title": "Analysis",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+		},
+        "AvailableFormats": {
+			"properties": {
+				"formatDbId": {
+                    "description": "When the data for a VariantSet is retrieved, it can be retrieved in a variety of data formats and file formats. \n<br/>'dataFormat' defines the structure of the data within a file (ie DartSeq, VCF, Hapmap, tabular, etc)\n<br/>'fileFormat' defines the MIME type of the file (ie text/csv, application/excel, application/zip). This should also be reflected in the Accept and ContentType HTTP headers for every relevant request and response.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "dataFormat": {
+                    "description": "dataFormat defines the structure of the data within a file (ie DartSeq, VCF, Hapmap, tabular, etc)",
+                    "enum": [
+                        "DartSeq",
+                        "VCF",
+                        "Hapmap",
+                        "tabular",
+                        "JSON",
+                        null
+                    ],
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "expandHomozygotes": {
+                    "description": "Should homozygotes be expanded (true) or collapsed into a single occurrence (false)",
+                    "type": [
+                        "null",
+                        "boolean"
+                    ]
+                },
+                "fileFormat": {
+                    "description": "fileFormat defines the MIME type of the file (ie text/csv, application/excel, application/zip). This should also be reflected in the Accept and ContentType HTTP headers for every relevant request and response.",
+                    "enum": [
+                        "text/csv",
+                        "text/tsv",
+                        "application/excel",
+                        "application/zip",
+                        "application/json",
+                        null
+                    ],
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "fileURL": {
+                    "description": "A URL which indicates the location of the file version of this VariantSet. Could be a static file URL or an API endpoint which generates the file.",
+                    "format": "uri",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "sepPhased": {
+                    "description": "The string used as a separator for phased allele calls.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "sepUnphased": {
+                    "description": "The string used as a separator for unphased allele calls.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "unknownString": {
+                    "description": "The string used as a representation for missing data.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "variantSet": {
+					"description": "Formats associated with a variant set",
+					"$ref": "../BrAPI-Genotyping/VariantSet.json#/$defs/VariantSet",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "availableFormats"
+				}
+			},
+			"required": [
+                "formatDbId"
+            ],
+            "title": "AvailableFormats",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+		},
+        "MetadataFields": {
+			"properties": {
+				"metadataFieldDbId": {
+                    "description": "This represents a type of genotyping data or metadata available in this VariantSet",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "dataType": {
+                    "description": "The type of field represented in this Genotype Field. This is intended to help parse the data out of JSON.",
+                    "enum": [
+                        "string",
+                        "integer",
+                        "float",
+                        "boolean",
+                        null
+                    ],
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "fieldAbbreviation": {
+                    "description": "The abbreviated code of the field represented in this Genotype Field. These codes should match the VCF standard when possible. Examples include: \"GQ\", \"RD\", and \"HQ\"",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "fieldName": {
+                    "description": "The name of the field represented in this Genotype Field. Examples include: \"Genotype Quality\", \"Read Depth\", and \"Haplotype Quality\"",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "variantSet": {
+					"description": "Formats associated with a variant set",
+					"$ref": "../BrAPI-Genotyping/VariantSet.json#/$defs/VariantSet",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "metadataFields"
+				}
+			},
+			"required": [
+                "metadataFieldDbId"
+            ],
+            "title": "MetadataFields",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+		}
+
     },
     "$id": "https://brapi.org/Specification/BrAPI-Schema/BrAPI-Genotyping/VariantSet.json",
     "$schema": "http://json-schema.org/draft/2020-12/schema"

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/Cross.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/Cross.json
@@ -4,22 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "crossAttributes": {
                     "description": "Set of custom attributes associated with a cross",
                     "relationshipType": "one-to-many",
                     "referencedAttribute": "cross",
                     "items": {
-                        "$ref": "../BrAPI-Germplasm/Cross.json#/$defs/CrossAttributes",
+                        "$ref": "../BrAPI-Germplasm/Cross.json#/$defs/CrossAttribute",
                         "description": "CrossAttributes"
                     },
                     "title": "CrossAttributes",
@@ -81,8 +74,8 @@
                     "relationshipType": "one-to-many",
                     "referencedAttribute": "cross",
                     "items": {
-                        "$ref": "../BrAPI-Germplasm/Cross.json#/$defs/PollinationEvents",
-                        "description": "PollinationEvents"
+                        "$ref": "../BrAPI-Germplasm/Cross.json#/$defs/PollinationEvent",
+                        "description": "PollinationEvent"
                     },
                     "title": "PollinationEvents",
                     "type": [
@@ -114,9 +107,9 @@
                 "primaryModel": true
             }
         },
-        "CrossAttributes": {
+        "CrossAttribute": {
             "properties": {
-                "attributeDbId": {
+                "crossAttributeDbId": {
                     "description": "the unique identifier for a cross attribute",
                     "type": "string"
                 },
@@ -142,7 +135,7 @@
                 }
             },
             "required": [
-                "crossDbId"
+                "crossAttributeDbId"
             ],
             "title": "CrossAttributes",
             "type": "object",
@@ -150,10 +143,10 @@
                 "primaryModel": true
             }
         },
-        "PollinationEvents": {
+        "PollinationEvent": {
             "properties": {
-                "eventDbId": {
-                    "description": "the unique identifier for a polination event",
+                "pollinationEventDbId": {
+                    "description": "the unique identifier for a pollination event",
                     "type": "string"
                 },
                 "pollinationNumber": {
@@ -186,7 +179,7 @@
                 }
             },
             "required": [
-                "eventDbId"
+                "pollinationEventDbId"
             ],
             "title": "PollinationEvents",
             "type": "object",

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/Cross.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/Cross.json
@@ -109,10 +109,6 @@
         },
         "CrossAttribute": {
             "properties": {
-                "crossAttributeDbId": {
-                    "description": "the unique identifier for a cross attribute",
-                    "type": "string"
-                },
                 "crossAttributeName": {
                     "description": "the human readable name of a cross attribute",
                     "type": [
@@ -134,9 +130,6 @@
                     "referencedAttribute": "crossAttributes"
                 }
             },
-            "required": [
-                "crossAttributeDbId"
-            ],
             "title": "CrossAttributes",
             "type": "object",
             "brapi-metadata": {
@@ -145,10 +138,6 @@
         },
         "PollinationEvent": {
             "properties": {
-                "pollinationEventDbId": {
-                    "description": "the unique identifier for a pollination event",
-                    "type": "string"
-                },
                 "pollinationNumber": {
                     "description": "The unique identifier for this pollination event",
                     "type": [
@@ -178,9 +167,6 @@
                     "referencedAttribute": "pollinationEvents"
                 }
             },
-            "required": [
-                "pollinationEventDbId"
-            ],
             "title": "PollinationEvents",
             "type": "object",
             "brapi-metadata": {

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/Cross.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/Cross.json
@@ -4,35 +4,30 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
-                },
-                "crossAttributes": {
-                    "description": "Set of custom attributes associated with a cross",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "description": "a custom attributes associated with a cross",
-                        "properties": {
-                            "crossAttributeName": {
-                                "description": "the human readable name of a cross attribute",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "crossAttributeValue": {
-                                "description": "the value of a cross attribute",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
                     },
                     "type": [
                         "null",
                         "array"
                     ]
                 },
+				"crossAttributes": {
+					"description": "Set of custom attributes associated with a cross",
+					"relationshipType": "one-to-many",
+					"referencedAttribute": "cross",
+                    "items": {
+                        "$ref": "../BrAPI-Germplasm/Cross.json#/$defs/CrossAttributes",
+                        "description": "CrossAttributes"
+                    },
+                    "title": "CrossAttributes",
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+				},
                 "crossDbId": {
                     "description": "the unique identifier for a cross",
                     "type": "string"
@@ -56,8 +51,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [
@@ -81,33 +78,13 @@
                 },
                 "pollinationEvents": {
                     "description": "The list of pollination events that occurred for this cross",
+					"relationshipType": "one-to-many",
+					"referencedAttribute": "cross",
                     "items": {
-                        "properties": {
-                            "pollinationNumber": {
-                                "description": "The unique identifier for this pollination event",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "pollinationSuccessful": {
-                                "description": "True if the pollination was successful",
-                                "type": [
-                                    "null",
-                                    "boolean"
-                                ]
-                            },
-                            "pollinationTimeStamp": {
-                                "description": "The timestamp when the pollination took place",
-                                "format": "date-time",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "../BrAPI-Germplasm/Cross.json#/$defs/PollinationEvents",
+                        "description": "PollinationEvents"
                     },
+                    "title": "PollinationEvents",
                     "type": [
                         "null",
                         "array"
@@ -136,7 +113,87 @@
             "brapi-metadata": {
                 "primaryModel": true
             }
-        }
+        },
+		"CrossAttributes": {
+			"properties": {
+				"attributeDbId": {
+					"description": "the unique identifier for a cross attribute",
+                    "type": "string"
+				},
+				"crossAttributeName": {
+					"description": "the human readable name of a cross attribute",
+					"type": [
+						"null",
+						"string"
+					]
+				},
+				"crossAttributeValue": {
+					"description": "the value of a cross attribute",
+					"type": [
+						"null",
+						"string"
+					]
+				},
+				"cross": {
+					"description": "a custom attributes associated with a cross",
+					"$ref": "../BrAPI-Germplasm/Cross.json#/$defs/Cross",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "crossAttributes"
+				}
+			},
+			"required": [
+                "crossDbId"
+            ],
+            "title": "CrossAttributes",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": true
+            }
+		},
+		"PollinationEvents": {
+			"properties": {
+				"eventDbId": {
+					"description": "the unique identifier for a polination event",
+                    "type": "string"
+				},
+				"pollinationNumber": {
+					"description": "The unique identifier for this pollination event",
+					"type": [
+						"null",
+						"string"
+					]
+				},
+				"pollinationSuccessful": {
+					"description": "True if the pollination was successful",
+					"type": [
+						"null",
+						"boolean"
+					]
+				},
+				"pollinationTimeStamp": {
+					"description": "The timestamp when the pollination took place",
+					"format": "date-time",
+					"type": [
+						"null",
+						"string"
+					]
+				},
+				"cross": {
+					"description": "polunation events associated with a cross",
+					"$ref": "../BrAPI-Germplasm/Cross.json#/$defs/Cross",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "pollinationEvents"
+				}
+			},
+			"required": [
+                "eventDbId"
+            ],
+            "title": "PollinationEvents",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+		}
     },
     "$id": "https://brapi.org/Specification/BrAPI-Schema/BrAPI-Germplasm/Cross.json",
     "$schema": "http://json-schema.org/draft/2020-12/schema"

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/Cross.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/Cross.json
@@ -14,10 +14,10 @@
                         "array"
                     ]
                 },
-				"crossAttributes": {
-					"description": "Set of custom attributes associated with a cross",
-					"relationshipType": "one-to-many",
-					"referencedAttribute": "cross",
+                "crossAttributes": {
+                    "description": "Set of custom attributes associated with a cross",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "cross",
                     "items": {
                         "$ref": "../BrAPI-Germplasm/Cross.json#/$defs/CrossAttributes",
                         "description": "CrossAttributes"
@@ -27,7 +27,7 @@
                         "null",
                         "array"
                     ]
-				},
+                },
                 "crossDbId": {
                     "description": "the unique identifier for a cross",
                     "type": "string"
@@ -78,8 +78,8 @@
                 },
                 "pollinationEvents": {
                     "description": "The list of pollination events that occurred for this cross",
-					"relationshipType": "one-to-many",
-					"referencedAttribute": "cross",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "cross",
                     "items": {
                         "$ref": "../BrAPI-Germplasm/Cross.json#/$defs/PollinationEvents",
                         "description": "PollinationEvents"
@@ -114,34 +114,34 @@
                 "primaryModel": true
             }
         },
-		"CrossAttributes": {
-			"properties": {
-				"attributeDbId": {
-					"description": "the unique identifier for a cross attribute",
+        "CrossAttributes": {
+            "properties": {
+                "attributeDbId": {
+                    "description": "the unique identifier for a cross attribute",
                     "type": "string"
-				},
-				"crossAttributeName": {
-					"description": "the human readable name of a cross attribute",
-					"type": [
-						"null",
-						"string"
-					]
-				},
-				"crossAttributeValue": {
-					"description": "the value of a cross attribute",
-					"type": [
-						"null",
-						"string"
-					]
-				},
-				"cross": {
-					"description": "a custom attributes associated with a cross",
-					"$ref": "../BrAPI-Germplasm/Cross.json#/$defs/Cross",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "crossAttributes"
-				}
-			},
-			"required": [
+                },
+                "crossAttributeName": {
+                    "description": "the human readable name of a cross attribute",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "crossAttributeValue": {
+                    "description": "the value of a cross attribute",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "cross": {
+                    "description": "a custom attributes associated with a cross",
+                    "$ref": "../BrAPI-Germplasm/Cross.json#/$defs/Cross",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "crossAttributes"
+                }
+            },
+            "required": [
                 "crossDbId"
             ],
             "title": "CrossAttributes",
@@ -149,43 +149,43 @@
             "brapi-metadata": {
                 "primaryModel": true
             }
-		},
-		"PollinationEvents": {
-			"properties": {
-				"eventDbId": {
-					"description": "the unique identifier for a polination event",
+        },
+        "PollinationEvents": {
+            "properties": {
+                "eventDbId": {
+                    "description": "the unique identifier for a polination event",
                     "type": "string"
-				},
-				"pollinationNumber": {
-					"description": "The unique identifier for this pollination event",
-					"type": [
-						"null",
-						"string"
-					]
-				},
-				"pollinationSuccessful": {
-					"description": "True if the pollination was successful",
-					"type": [
-						"null",
-						"boolean"
-					]
-				},
-				"pollinationTimeStamp": {
-					"description": "The timestamp when the pollination took place",
-					"format": "date-time",
-					"type": [
-						"null",
-						"string"
-					]
-				},
-				"cross": {
-					"description": "polunation events associated with a cross",
-					"$ref": "../BrAPI-Germplasm/Cross.json#/$defs/Cross",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "pollinationEvents"
-				}
-			},
-			"required": [
+                },
+                "pollinationNumber": {
+                    "description": "The unique identifier for this pollination event",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "pollinationSuccessful": {
+                    "description": "True if the pollination was successful",
+                    "type": [
+                        "null",
+                        "boolean"
+                    ]
+                },
+                "pollinationTimeStamp": {
+                    "description": "The timestamp when the pollination took place",
+                    "format": "date-time",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "cross": {
+                    "description": "polunation events associated with a cross",
+                    "$ref": "../BrAPI-Germplasm/Cross.json#/$defs/Cross",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "pollinationEvents"
+                }
+            },
+            "required": [
                 "eventDbId"
             ],
             "title": "PollinationEvents",
@@ -193,7 +193,7 @@
             "brapi-metadata": {
                 "primaryModel": false
             }
-		}
+        }
     },
     "$id": "https://brapi.org/Specification/BrAPI-Schema/BrAPI-Germplasm/Cross.json",
     "$schema": "http://json-schema.org/draft/2020-12/schema"

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/CrossParent.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/CrossParent.json
@@ -2,8 +2,16 @@
     "$defs": {
         "CrossParent": {
             "properties": {
+				"crossParentDbId": {
+                    "description": "The ID which uniquely identifies a cross parent",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
                 "germplasm": {
                     "description": "the germplasm of the cross parent",
+					"relationshipType": "one-to-one",
                     "$ref": "Germplasm.json#/$defs/Germplasm",
                     "type": [
                         "null",
@@ -12,6 +20,7 @@
                 },
                 "observationUnit": {
                     "description": "the Observation Unit of the cross parent",
+                    "relationshipType": "one-to-one",
                     "$ref": "../BrAPI-Phenotyping/ObservationUnit.json#/$defs/ObservationUnit",
                     "type": [
                         "null",

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/CrossingProject.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/CrossingProject.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "commonCropName": {
                     "description": "the common name of a crop (for multi-crop systems)",
@@ -30,8 +38,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/CrossingProject.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/CrossingProject.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "commonCropName": {
                     "description": "the common name of a crop (for multi-crop systems)",

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/Germplasm.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/Germplasm.json
@@ -18,15 +18,8 @@
                 },
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "biologicalStatusOfAccessionCode": {
                     "description": "MCPD (v2.1) (SAMPSTAT) 19. The coding scheme proposed can be used at 3 different levels of detail: either by using the general codes such as 100, 200, 300, 400, or by using the more specific codes such as 110, 120, etc. \n\n100) Wild \n110) Natural \n120) Semi-natural/wild \n130) Semi-natural/sown \n200) Weedy \n300) Traditional cultivar/landrace \n400) Breeding/research material \n410) Breeders line \n411) Synthetic population \n412) Hybrid \n413) Founder stock/base population \n414) Inbred line (parent of hybrid cultivar) \n415) Segregating population \n416) Clonal selection \n420) Genetic stock \n421) Mutant (e.g. induced/insertion mutants, tilling populations) \n422) Cytogenetic stocks (e.g. chromosome addition/substitution, aneuploids,  amphiploids) \n423) Other genetic stocks (e.g. mapping populations) \n500) Advanced or improved cultivar (conventional breeding methods) \n600) GMO (by genetic engineering) \n999) Other (Elaborate in REMARKS field)",
@@ -116,7 +109,7 @@
                     "relationshipType": "one-to-many",
                     "referencedAttribute": "germplasm",
                     "items": {
-                        "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Donors",
+                        "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Donor",
                         "description": "Donors"
                     },
                     "title": "Donors",
@@ -232,7 +225,7 @@
                     "relationshipType": "one-to-many",
                     "referencedAttribute": "germplasm",
                     "items": {
-                        "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/StorageTypes",
+                        "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/StorageType",
                         "description": "StorageTypes"
                     },
                     "title": "StorageTypes",
@@ -260,7 +253,7 @@
                     "relationshipType": "one-to-many",
                     "referencedAttribute": "germplasm",
                     "items": {
-                        "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Synonyms",
+                        "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Synonym",
                         "description": "Synonyms"
                     },
                     "title": "Synonyms",
@@ -274,10 +267,10 @@
                     "relationshipType": "one-to-many",
                     "referencedAttribute": "germplasm",
                     "items": {
-                        "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Synonyms",
-                        "description": "Synonyms"
+                        "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/TaxonId",
+                        "description": "TaxonIds"
                     },
-                    "title": "Synonyms",
+                    "title": "TaxonIds",
                     "type": [
                         "null",
                         "array"
@@ -391,7 +384,7 @@
                 "primaryModel": true
             }
         },
-        "Donors": {
+        "Donor": {
             "properties": {
                 "donorDbId": {
                     "description": "the unique identifier for a donor",
@@ -429,7 +422,7 @@
         },
         "GermplasmOrigin": {
             "properties": {
-                "originDbId": {
+                "germplasmOriginDbId": {
                     "description": "the unique identifier for a origin",
                     "type": "string"
                 },
@@ -462,7 +455,7 @@
                 }
             },
             "required": [
-                "originDbId"
+                "germplasmOriginDbId"
             ],
             "title": "GermplasmOrigin",
             "type": "object",
@@ -470,9 +463,9 @@
                 "primaryModel": false
             }
         },
-        "StorageTypes": {
+        "StorageType": {
             "properties": {
-                "storageDbId": {
+                "storageTypeDbId": {
                     "description": "the unique identifier for a storage type",
                     "type": "string"
                 },
@@ -510,7 +503,7 @@
                 }
             },
             "required": [
-                "storageDbId"
+                "storageTypeDbId"
             ],
             "title": "StorageTypes",
             "type": "object",
@@ -518,7 +511,7 @@
                 "primaryModel": false
             }
         },
-        "Synonyms": {
+        "Synonym": {
             "properties": {
                 "synonymDbId": {
                     "description": "the unique identifier for a synonym",
@@ -554,9 +547,9 @@
                 "primaryModel": false
             }
         },
-        "TaxonIds": {
+        "TaxonId": {
             "properties": {
-                "taxonDbId": {
+                "taxonIdDbId": {
                     "description": "The identifier (name, ID, URI) of a particular taxonomy within the source provider",
                     "type": "string"
                 },
@@ -577,7 +570,7 @@
             },
             "required": [
                 "sourceName",
-                "taxonDbId",
+                "taxonIdDbId",
                 "taxonId"
             ],
             "title": "TaxonIds",

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/Germplasm.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/Germplasm.json
@@ -114,7 +114,7 @@
                 "donors": {
                     "description": "List of donor institutes",
                     "relationshipType": "one-to-many",
-					"referencedAttribute": "germplasm",
+                    "referencedAttribute": "germplasm",
                     "items": {
                         "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Donors",
                         "description": "Donors"
@@ -156,7 +156,7 @@
                 "germplasmOrigin": {
                     "description": "Information for material (orchard, natural sites, ...). Geographic identification of the plants from which seeds or cutting have been taken to produce that germplasm.",
                     "relationshipType": "one-to-many",
-					"referencedAttribute": "germplasm",
+                    "referencedAttribute": "germplasm",
                     "items": {
                         "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/GermplasmOrigin",
                         "description": "GermplasmOrigin"
@@ -230,7 +230,7 @@
                 "storageTypes": {
                     "description": "The type of storage this germplasm is kept in at a genebank.",
                     "relationshipType": "one-to-many",
-					"referencedAttribute": "germplasm",
+                    "referencedAttribute": "germplasm",
                     "items": {
                         "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/StorageTypes",
                         "description": "StorageTypes"
@@ -258,7 +258,7 @@
                 "synonyms": {
                     "description": "List of alternative names or IDs used to reference this germplasm\n\nMCPD (v2.1) (OTHERNUMB) 24. Any other identifiers known to exist in other collections for this accession. Use the following format: INSTCODE:ACCENUMB;INSTCODE:identifier;INSTCODE and identifier are separated by a colon without space. Pairs of INSTCODE and identifier are separated by a semicolon without space. When the institute is not known, the identifier should be preceded by a colon.",
                     "relationshipType": "one-to-many",
-					"referencedAttribute": "germplasm",
+                    "referencedAttribute": "germplasm",
                     "items": {
                         "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Synonyms",
                         "description": "Synonyms"
@@ -272,7 +272,7 @@
                 "taxonIds": {
                     "description": "The list of IDs for this SPECIES from different sources. If present, NCBI Taxon should be always listed as \"ncbiTaxon\" preferably with a purl. The rank of this ID should be species.\n\nMIAPPE V1.1 (DM-42) Organism - An identifier for the organism at the species level. Use of the NCBI taxon ID is recommended.",
                     "relationshipType": "one-to-many",
-					"referencedAttribute": "germplasm",
+                    "referencedAttribute": "germplasm",
                     "items": {
                         "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Synonyms",
                         "description": "Synonyms"
@@ -391,34 +391,34 @@
                 "primaryModel": true
             }
         },
-		"Donors": {
+        "Donors": {
             "properties": {
-				"donorDbId": {
-					"description": "the unique identifier for a donor",
+                "donorDbId": {
+                    "description": "the unique identifier for a donor",
                     "type": "string"
-				},
-				"donorAccessionNumber": {
-					"description": "The accession number assigned by the donor\n\nMCPD (v2.1) (DONORNUMB) 23. Identifier assigned to an accession by the donor. Follows ACCENUMB standard.",
-					"type": [
-						"null",
-						"string"
-					]
-				},
-				"donorInstituteCode": {
-					"description": "The institute code for the donor institute\n<br/>MCPD (v2.1) (DONORCODE) 22. FAO WIEWS code of the donor institute. Follows INSTCODE standard.",
-					"type": [
-						"null",
-						"string"
-					]
-				},
-				"germplasm": {
-					"description": "donoers associated with a germplasm",
-					"$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Germplasm",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "donors"
-				}
-			},
-			"required": [
+                },
+                "donorAccessionNumber": {
+                    "description": "The accession number assigned by the donor\n\nMCPD (v2.1) (DONORNUMB) 23. Identifier assigned to an accession by the donor. Follows ACCENUMB standard.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "donorInstituteCode": {
+                    "description": "The institute code for the donor institute\n<br/>MCPD (v2.1) (DONORCODE) 22. FAO WIEWS code of the donor institute. Follows INSTCODE standard.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "germplasm": {
+                    "description": "donoers associated with a germplasm",
+                    "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Germplasm",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "donors"
+                }
+            },
+            "required": [
                 "donorDbId"
             ],
             "title": "Donors",
@@ -426,7 +426,7 @@
             "brapi-metadata": {
                 "primaryModel": false
             }
-		},
+        },
         "GermplasmOrigin": {
             "properties": {
                 "originDbID": {
@@ -456,9 +456,9 @@
                 },
                 "germplasm": {
                     "description": "associated germplasm",
-					"$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Germplasm",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "germplasmOrigin"
+                    "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Germplasm",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "germplasmOrigin"
                 }
             },
             "required": [
@@ -504,9 +504,9 @@
                 },
                 "germplasm": {
                     "description": "associated germplasm",
-					"$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Germplasm",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "storageTypes"
+                    "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Germplasm",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "storageTypes"
                 }
             },
             "required": [
@@ -540,9 +540,9 @@
                 },
                 "germplasm": {
                     "description": "associated germplasm",
-					"$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Germplasm",
-					"relationshipType": "many-to-one",
-					"referencedAttribute": "synonyms"
+                    "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Germplasm",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "synonyms"
                 }
             },
             "required": [

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/Germplasm.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/Germplasm.json
@@ -429,8 +429,8 @@
         },
         "GermplasmOrigin": {
             "properties": {
-                "originDbID": {
-                    "description": "the unique idenifier for a origin",
+                "originDbId": {
+                    "description": "the unique identifier for a origin",
                     "type": "string"
                 },
                 "coordinateUncertainty": {
@@ -472,8 +472,8 @@
         },
         "StorageTypes": {
             "properties": {
-                "storageDbID": {
-                    "description": "the unique idenifier for a storage type",
+                "storageDbId": {
+                    "description": "the unique identifier for a storage type",
                     "type": "string"
                 },
                 "code": {
@@ -521,7 +521,7 @@
         "Synonyms": {
             "properties": {
                 "synonymDbId": {
-                    "description": "the unique idenifier for a synonym",
+                    "description": "the unique identifier for a synonym",
                     "type": "string"
                 },
                 "synonym": {

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/Germplasm.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/Germplasm.json
@@ -422,10 +422,6 @@
         },
         "GermplasmOrigin": {
             "properties": {
-                "germplasmOriginDbId": {
-                    "description": "the unique identifier for a origin",
-                    "type": "string"
-                },
                 "coordinateUncertainty": {
                     "description": "Uncertainty associated with the coordinates in meters. Leave the value empty if the uncertainty is unknown.",
                     "type": [
@@ -454,9 +450,6 @@
                     "referencedAttribute": "germplasmOrigin"
                 }
             },
-            "required": [
-                "germplasmOriginDbId"
-            ],
             "title": "GermplasmOrigin",
             "type": "object",
             "brapi-metadata": {
@@ -465,10 +458,6 @@
         },
         "StorageType": {
             "properties": {
-                "storageTypeDbId": {
-                    "description": "the unique identifier for a storage type",
-                    "type": "string"
-                },
                 "code": {
                     "description": "The 2 digit code representing the type of storage this germplasm is kept in at a genebank. \n\nMCPD (v2.1) (STORAGE) 26. If germplasm is maintained under different types of storage, multiple choices are allowed, separated by a semicolon (e.g. 20;30). (Refer to FAO/IPGRI Genebank Standards 1994 for details on storage type.) \n\n10) Seed collection \n11) Short term \n12) Medium term \n13) Long term \n20) Field collection \n30) In vitro collection \n40) Cryo-preserved collection \n50) DNA collection \n99) Other (elaborate in REMARKS field)",
                     "enum": [
@@ -502,9 +491,6 @@
                     "referencedAttribute": "storageTypes"
                 }
             },
-            "required": [
-                "storageTypeDbId"
-            ],
             "title": "StorageTypes",
             "type": "object",
             "brapi-metadata": {
@@ -549,7 +535,7 @@
         },
         "TaxonId": {
             "properties": {
-                "taxonIdDbId": {
+                "taxonDbId": {
                     "description": "The identifier (name, ID, URI) of a particular taxonomy within the source provider",
                     "type": "string"
                 },
@@ -570,7 +556,7 @@
             },
             "required": [
                 "sourceName",
-                "taxonIdDbId",
+                "taxonDbId",
                 "taxonId"
             ],
             "title": "TaxonIds",

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/Germplasm.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/Germplasm.json
@@ -18,7 +18,15 @@
                 },
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "biologicalStatusOfAccessionCode": {
                     "description": "MCPD (v2.1) (SAMPSTAT) 19. The coding scheme proposed can be used at 3 different levels of detail: either by using the general codes such as 100, 200, 300, 400, or by using the more specific codes such as 110, 120, etc. \n\n100) Wild \n110) Natural \n120) Semi-natural/wild \n130) Semi-natural/sown \n200) Weedy \n300) Traditional cultivar/landrace \n400) Breeding/research material \n410) Breeders line \n411) Synthetic population \n412) Hybrid \n413) Founder stock/base population \n414) Inbred line (parent of hybrid cultivar) \n415) Segregating population \n416) Clonal selection \n420) Genetic stock \n421) Mutant (e.g. induced/insertion mutants, tilling populations) \n422) Cytogenetic stocks (e.g. chromosome addition/substitution, aneuploids,  amphiploids) \n423) Other genetic stocks (e.g. mapping populations) \n500) Advanced or improved cultivar (conventional breeding methods) \n600) GMO (by genetic engineering) \n999) Other (Elaborate in REMARKS field)",
@@ -105,25 +113,13 @@
                 },
                 "donors": {
                     "description": "List of donor institutes",
+                    "relationshipType": "one-to-many",
+					"referencedAttribute": "germplasm",
                     "items": {
-                        "properties": {
-                            "donorAccessionNumber": {
-                                "description": "The accession number assigned by the donor\n                              \nMCPD (v2.1) (DONORNUMB) 23. Identifier assigned to an accession by the donor. Follows ACCENUMB standard.",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "donorInstituteCode": {
-                                "description": "The institute code for the donor institute\n<br/>MCPD (v2.1) (DONORCODE) 22. FAO WIEWS code of the donor institute. Follows INSTCODE standard.",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Donors",
+                        "description": "Donors"
                     },
+                    "title": "Donors",
                     "type": [
                         "null",
                         "array"
@@ -131,8 +127,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [
@@ -157,41 +155,13 @@
                 },
                 "germplasmOrigin": {
                     "description": "Information for material (orchard, natural sites, ...). Geographic identification of the plants from which seeds or cutting have been taken to produce that germplasm.",
+                    "relationshipType": "one-to-many",
+					"referencedAttribute": "germplasm",
                     "items": {
-                        "description": "MIAPPE V1.1 (DM-52) \n\nMIAPPE V1.1 (DM-53) \n\nMIAPPE V1.1 (DM-54) \n\nMIAPPE V1.1 (DM-55)\n\nMCPD (v2.1) (COORDUNCERT) 15.5 \n\nMCPD (v2.1) (ELEVATION) 16. \n\nMCPD (v2.1) (GEOREFMETH) 15.7 \n\nMCPD (v2.1) (DECLATITUDE) 15.1 \n\nMCPD (v2.1) (DECLONGITUDE) 15.3 ",
-                        "properties": {
-                            "coordinateUncertainty": {
-                                "description": "Uncertainty associated with the coordinates in meters. Leave the value empty if the uncertainty is unknown.",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "coordinates": {
-                                "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.\n\nCopied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element.",
-                                "properties": {
-                                    "geometry": {
-                                        "description": "A geometry as defined by GeoJSON (RFC 7946). In this context, only Point or Polygon geometry are allowed.",
-                                        "$ref": "../BrAPI-Common/GeoJSONGeometry.json#/$defs/GeoJSONGeometry"
-                                    },
-                                    "type": {
-                                        "default": "Feature",
-                                        "description": "The literal string \"Feature\"",
-                                        "type": [
-                                            "null",
-                                            "string"
-                                        ]
-                                    }
-                                },
-                                "title": "GeoJSON",
-                                "type": [
-                                    "null",
-                                    "object"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/GermplasmOrigin",
+                        "description": "GermplasmOrigin"
                     },
+                    "title": "GermplasmOrigin",
                     "type": [
                         "null",
                         "array"
@@ -259,37 +229,13 @@
                 },
                 "storageTypes": {
                     "description": "The type of storage this germplasm is kept in at a genebank.",
+                    "relationshipType": "one-to-many",
+					"referencedAttribute": "germplasm",
                     "items": {
-                        "properties": {
-                            "code": {
-                                "description": "The 2 digit code representing the type of storage this germplasm is kept in at a genebank. \n\nMCPD (v2.1) (STORAGE) 26. If germplasm is maintained under different types of storage, multiple choices are allowed, separated by a semicolon (e.g. 20;30). (Refer to FAO/IPGRI Genebank Standards 1994 for details on storage type.) \n\n10) Seed collection \n11) Short term \n12) Medium term \n13) Long term \n20) Field collection \n30) In vitro collection \n40) Cryo-preserved collection \n50) DNA collection \n99) Other (elaborate in REMARKS field)",
-                                "enum": [
-                                    "10",
-                                    "11",
-                                    "12",
-                                    "13",
-                                    "20",
-                                    "30",
-                                    "40",
-                                    "50",
-                                    "99",
-                                    null
-                                ],
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "description": {
-                                "description": "A supplemental text description of the storage type",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/StorageTypes",
+                        "description": "StorageTypes"
                     },
+                    "title": "StorageTypes",
                     "type": [
                         "null",
                         "array"
@@ -311,25 +257,13 @@
                 },
                 "synonyms": {
                     "description": "List of alternative names or IDs used to reference this germplasm\n\nMCPD (v2.1) (OTHERNUMB) 24. Any other identifiers known to exist in other collections for this accession. Use the following format: INSTCODE:ACCENUMB;INSTCODE:identifier;INSTCODE and identifier are separated by a colon without space. Pairs of INSTCODE and identifier are separated by a semicolon without space. When the institute is not known, the identifier should be preceded by a colon.",
+                    "relationshipType": "one-to-many",
+					"referencedAttribute": "germplasm",
                     "items": {
-                        "properties": {
-                            "synonym": {
-                                "description": "Alternative name or ID used to reference this germplasm",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "type": {
-                                "description": "A descriptive classification for this synonym",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Synonyms",
+                        "description": "Synonyms"
                     },
+                    "title": "Synonyms",
                     "type": [
                         "null",
                         "array"
@@ -337,23 +271,13 @@
                 },
                 "taxonIds": {
                     "description": "The list of IDs for this SPECIES from different sources. If present, NCBI Taxon should be always listed as \"ncbiTaxon\" preferably with a purl. The rank of this ID should be species.\n\nMIAPPE V1.1 (DM-42) Organism - An identifier for the organism at the species level. Use of the NCBI taxon ID is recommended.",
+                    "relationshipType": "one-to-many",
+					"referencedAttribute": "germplasm",
                     "items": {
-                        "properties": {
-                            "sourceName": {
-                                "description": "The human readable name of the taxonomy provider",
-                                "type": "string"
-                            },
-                            "taxonId": {
-                                "description": "The identifier (name, ID, URI) of a particular taxonomy within the source provider",
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "sourceName",
-                            "taxonId"
-                        ],
-                        "type": "object"
+                        "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Synonyms",
+                        "description": "Synonyms"
                     },
+                    "title": "Synonyms",
                     "type": [
                         "null",
                         "array"
@@ -465,6 +389,201 @@
             "type": "object",
             "brapi-metadata": {
                 "primaryModel": true
+            }
+        },
+		"Donors": {
+            "properties": {
+				"donorDbId": {
+					"description": "the unique identifier for a donor",
+                    "type": "string"
+				},
+				"donorAccessionNumber": {
+					"description": "The accession number assigned by the donor\n\nMCPD (v2.1) (DONORNUMB) 23. Identifier assigned to an accession by the donor. Follows ACCENUMB standard.",
+					"type": [
+						"null",
+						"string"
+					]
+				},
+				"donorInstituteCode": {
+					"description": "The institute code for the donor institute\n<br/>MCPD (v2.1) (DONORCODE) 22. FAO WIEWS code of the donor institute. Follows INSTCODE standard.",
+					"type": [
+						"null",
+						"string"
+					]
+				},
+				"germplasm": {
+					"description": "donoers associated with a germplasm",
+					"$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Germplasm",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "donors"
+				}
+			},
+			"required": [
+                "donorDbId"
+            ],
+            "title": "Donors",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+		},
+        "GermplasmOrigin": {
+            "properties": {
+                "originDbID": {
+                    "description": "the unique idenifier for a origin",
+                    "type": "string"
+                },
+                "coordinateUncertainty": {
+                    "description": "Uncertainty associated with the coordinates in meters. Leave the value empty if the uncertainty is unknown.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "coordinates": {
+                    "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.\n\nCopied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element.",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "germplasmOrigin",
+                    "items": {
+                        "$ref": "../BrAPI-Common/GeoJSON.json#/$defs/GeoJSON",
+                        "description": "A geometry as defined by GeoJSON (RFC 7946). In this context, only Point or Polygon geometry are allowed."
+                    },
+                    "title": "GeoJSON",
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "germplasm": {
+                    "description": "associated germplasm",
+					"$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Germplasm",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "germplasmOrigin"
+                }
+            },
+            "required": [
+                "originDbId"
+            ],
+            "title": "GermplasmOrigin",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+        },
+        "StorageTypes": {
+            "properties": {
+                "storageDbID": {
+                    "description": "the unique idenifier for a storage type",
+                    "type": "string"
+                },
+                "code": {
+                    "description": "The 2 digit code representing the type of storage this germplasm is kept in at a genebank. \n\nMCPD (v2.1) (STORAGE) 26. If germplasm is maintained under different types of storage, multiple choices are allowed, separated by a semicolon (e.g. 20;30). (Refer to FAO/IPGRI Genebank Standards 1994 for details on storage type.) \n\n10) Seed collection \n11) Short term \n12) Medium term \n13) Long term \n20) Field collection \n30) In vitro collection \n40) Cryo-preserved collection \n50) DNA collection \n99) Other (elaborate in REMARKS field)",
+                    "enum": [
+                        "10",
+                        "11",
+                        "12",
+                        "13",
+                        "20",
+                        "30",
+                        "40",
+                        "50",
+                        "99",
+                        null
+                    ],
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "description": {
+                    "description": "A supplemental text description of the storage type",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "germplasm": {
+                    "description": "associated germplasm",
+					"$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Germplasm",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "storageTypes"
+                }
+            },
+            "required": [
+                "storageDbId"
+            ],
+            "title": "StorageTypes",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+        },
+        "Synonyms": {
+            "properties": {
+                "synonymDbId": {
+                    "description": "the unique idenifier for a synonym",
+                    "type": "string"
+                },
+                "synonym": {
+                    "description": "Alternative name or ID used to reference this germplasm",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "type": {
+                    "description": "A descriptive classification for this synonym",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "germplasm": {
+                    "description": "associated germplasm",
+					"$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Germplasm",
+					"relationshipType": "many-to-one",
+					"referencedAttribute": "synonyms"
+                }
+            },
+            "required": [
+                "synonymDbId"
+            ],
+            "title": "Synonyms",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+        },
+        "TaxonIds": {
+            "properties": {
+                "taxonDbId": {
+                    "description": "The identifier (name, ID, URI) of a particular taxonomy within the source provider",
+                    "type": "string"
+                },
+                "taxonId": {
+                    "description": "The identifier (name, ID, URI) of a particular taxonomy within the source provider",
+                    "type": "string"
+                },
+                "sourceName": {
+                    "description": "The human readable name of the taxonomy provider",
+                    "type": "string"
+                },
+                "germplasm": {
+                    "description": "associated germplasm",
+                    "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Germplasm",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "taxonIds"
+                }
+            },
+            "required": [
+                "sourceName",
+                "taxonDbId",
+                "taxonId"
+            ],
+            "title": "TaxonIds",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
             }
         }
     },

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/GermplasmAttribute.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/GermplasmAttribute.json
@@ -8,6 +8,13 @@
                 {
                     "type": "object",
                     "properties": {
+						"germplasmAttributeDbId": {
+							"description": "The ID which uniquely identifies a germplasm attribute",
+							"type": [
+								"null",
+								"string"
+							]
+						},
                         "attributeValues": {
                             "title": "attributeValues",
                             "description": "attributeValues",

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/GermplasmAttributeValue.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/GermplasmAttributeValue.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "attribute": {
                     "$ref": "GermplasmAttribute.json#/$defs/GermplasmAttribute",
@@ -26,8 +34,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/GermplasmAttributeValue.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/GermplasmAttributeValue.json
@@ -13,7 +13,7 @@
                     "referencedAttribute": "attributeValues",
                     "relationshipType": "many-to-one"
                 },
-                "germplasmAttributeValueDbId": {
+                "attributeValueDbId": {
                     "description": "The ID which uniquely identifies this attribute value within the given database server",
                     "type": "string"
                 },

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/GermplasmAttributeValue.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/GermplasmAttributeValue.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "relationshipType": "one-to-one",
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
                 },
                 "attribute": {
                     "$ref": "GermplasmAttribute.json#/$defs/GermplasmAttribute",
@@ -20,7 +13,7 @@
                     "referencedAttribute": "attributeValues",
                     "relationshipType": "many-to-one"
                 },
-                "attributeValueDbId": {
+                "germplasmAttributeValueDbId": {
                     "description": "The ID which uniquely identifies this attribute value within the given database server",
                     "type": "string"
                 },

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/PedigreeNode.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/PedigreeNode.json
@@ -69,7 +69,7 @@
                 "parents": {
                     "description": "A list of parent germplasm references in the pedigree tree for this germplasm. These represent edges in the tree, connecting to other nodes.\n<br/> Typically, this array should only have one parent (clonal or self) or two parents (cross). In some special cases, there may be more parents, usually when the exact parent is not known. \n<br/> If the parameter 'includeParents' is set to false, then this array should be empty, null, or not present in the response.",
                     "relationshipType": "one-to-many",
-					"referencedAttribute": "pedigreeNode",
+                    "referencedAttribute": "pedigreeNode",
                     "items": {
                         "$ref": "../BrAPI-Germplasm/PedigreeNode.json#/$defs/Parents",
                         "description": "Parents"
@@ -90,7 +90,7 @@
                 "progeny": {
                     "description": "A list of germplasm references that are direct children of this germplasm. These represent edges in the tree, connecting to other nodes.\n<br/> The given germplasm could have a large number of progeny, across a number of different breeding methods. The 'parentType' shows \n      the type of parent this germplasm is to each of the child germplasm references.\n<br/> If the parameter 'includeProgeny' is set to false, then this array should be empty, null, or not present in the response.",
                     "relationshipType": "one-to-many",
-					"referencedAttribute": "pedigreeNode",
+                    "referencedAttribute": "pedigreeNode",
                     "items": {
                         "$ref": "../BrAPI-Germplasm/PedigreeNode.json#/$defs/Progeny",
                         "description": "Progeny"

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/PedigreeNode.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/PedigreeNode.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "relationshipType": "one-to-one",
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
                 },
                 "breedingMethod": {
                     "$ref": "BreedingMethod.json#/$defs/BreedingMethod",
@@ -71,13 +64,20 @@
                     "relationshipType": "one-to-many",
                     "referencedAttribute": "pedigreeNode",
                     "items": {
-                        "$ref": "../BrAPI-Germplasm/PedigreeNode.json#/$defs/Parents",
-                        "description": "Parents"
+                        "$ref": "../BrAPI-Germplasm/PedigreeNode.json#/$defs/GermplasmParent",
+                        "description": "GermplasmParents"
                     },
-                    "title": "Parents",
+                    "title": "GermplasmParents",
                     "type": [
                         "null",
                         "array"
+                    ]
+                },
+				"pedigreeNodeDbId": {
+                    "description": "The ID which uniquely identifies a pedigree node",
+                    "type": [
+                        "null",
+                        "string"
                     ]
                 },
                 "pedigreeString": {
@@ -92,7 +92,7 @@
                     "relationshipType": "one-to-many",
                     "referencedAttribute": "pedigreeNode",
                     "items": {
-                        "$ref": "../BrAPI-Germplasm/PedigreeNode.json#/$defs/Progeny",
+                        "$ref": "../BrAPI-Germplasm/PedigreeNode.json#/$defs/GermplasmChild",
                         "description": "Progeny"
                     },
                     "title": "Progeny",
@@ -124,9 +124,9 @@
                 "primaryModel": true
             }
         },
-        "Parents": {
+        "GermplasmParent": {
             "properties": {
-                "parentDbId": {
+                "germplasmParentDbId": {
                     "description": "a unique identifiere for a parent",
                     "type": "string"
                 },
@@ -158,9 +158,9 @@
                 "primaryModel": false
             }
         },
-        "Progeny": {
+        "GermplasmChild": {
             "properties": {
-                "parentDbId": {
+                "germplasmChildDbId": {
                     "description": "a unique identifiere for a progeny",
                     "type": "string"
                 },
@@ -182,7 +182,7 @@
                 }
             },
             "required": [
-                "progenyDbId",
+                "germplasmChildDbId",
                 "progenyGermplasm",
                 "parentType"
             ],

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/PedigreeNode.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/PedigreeNode.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "breedingMethod": {
                     "$ref": "BreedingMethod.json#/$defs/BreedingMethod",
@@ -34,8 +42,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [
@@ -58,26 +68,13 @@
                 },
                 "parents": {
                     "description": "A list of parent germplasm references in the pedigree tree for this germplasm. These represent edges in the tree, connecting to other nodes.\n<br/> Typically, this array should only have one parent (clonal or self) or two parents (cross). In some special cases, there may be more parents, usually when the exact parent is not known. \n<br/> If the parameter 'includeParents' is set to false, then this array should be empty, null, or not present in the response.",
+                    "relationshipType": "one-to-many",
+					"referencedAttribute": "pedigreeNode",
                     "items": {
-                        "title": "GermplasmParent",
-                        "properties": {
-                            "parentGermplasm": {
-                                "$ref": "Germplasm.json#/$defs/Germplasm",
-                                "description": "The ID which uniquely identifies a parent germplasm",
-                                "referencedAttribute": "progenyPedigreeNodes",
-                                "relationshipType": "many-to-one"
-                            },
-                            "parentType": {
-                                "description": "The type of parent used during crossing. Accepted values for this field are 'MALE', 'FEMALE', 'SELF', 'POPULATION', and 'CLONAL'. \n\nIn a pedigree record, the 'parentType' describes each parent of a particular germplasm. \n\nIn a progeny record, the 'parentType' is used to describe how this germplasm was crossed to generate a particular progeny. \nFor example, given a record for germplasm A, having a progeny B and C. The 'parentType' field for progeny B item refers \nto the 'parentType' of A toward B. The 'parentType' field for progeny C item refers to the 'parentType' of A toward C.\nIn this way, A could be a male parent to B, but a female parent to C. ",
-                                "$ref": "ParentType.json#/$defs/ParentType"
-                            }
-                        },
-                        "required": [
-                            "parentGermplasm",
-                            "parentType"
-                        ],
-                        "type": "object"
+                        "$ref": "../BrAPI-Germplasm/PedigreeNode.json#/$defs/Parents",
+                        "description": "Parents"
                     },
+                    "title": "Parents",
                     "type": [
                         "null",
                         "array"
@@ -92,26 +89,13 @@
                 },
                 "progeny": {
                     "description": "A list of germplasm references that are direct children of this germplasm. These represent edges in the tree, connecting to other nodes.\n<br/> The given germplasm could have a large number of progeny, across a number of different breeding methods. The 'parentType' shows \n      the type of parent this germplasm is to each of the child germplasm references.\n<br/> If the parameter 'includeProgeny' is set to false, then this array should be empty, null, or not present in the response.",
+                    "relationshipType": "one-to-many",
+					"referencedAttribute": "pedigreeNode",
                     "items": {
-                        "title": "GermplasmChild",
-                        "properties": {
-                            "progenyGermplasm": {
-                                "$ref": "Germplasm.json#/$defs/Germplasm",
-                                "description": "The ID which uniquely identifies a parent germplasm",
-                                "referencedAttribute": "parentPedigreeNodes",
-                                "relationshipType": "many-to-one"
-                            },
-                            "parentType": {
-                                "description": "The type of parent used during crossing. Accepted values for this field are 'MALE', 'FEMALE', 'SELF', 'POPULATION', and 'CLONAL'. \n\nIn a pedigree record, the 'parentType' describes each parent of a particular germplasm. \n\nIn a progeny record, the 'parentType' is used to describe how this germplasm was crossed to generate a particular progeny. \nFor example, given a record for germplasm A, having a progeny B and C. The 'parentType' field for progeny B item refers \nto the 'parentType' of A toward B. The 'parentType' field for progeny C item refers to the 'parentType' of A toward C.\nIn this way, A could be a male parent to B, but a female parent to C. ",
-                                "$ref": "ParentType.json#/$defs/ParentType"
-                            }
-                        },
-                        "required": [
-                            "progenyGermplasm",
-                            "parentType"
-                        ],
-                        "type": "object"
+                        "$ref": "../BrAPI-Germplasm/PedigreeNode.json#/$defs/Progeny",
+                        "description": "Progeny"
                     },
+                    "title": "Progeny",
                     "type": [
                         "null",
                         "array"
@@ -138,6 +122,74 @@
             "type": "object",
             "brapi-metadata": {
                 "primaryModel": true
+            }
+        },
+        "Parents": {
+            "properties": {
+                "parentDbId": {
+                    "description": "a unique identifiere for a parent",
+                    "type": "string"
+                },
+                "parentGermplasm": {
+                    "$ref": "Germplasm.json#/$defs/Germplasm",
+                    "description": "The ID which uniquely identifies a parent germplasm",
+                    "referencedAttribute": "progenyPedigreeNodes",
+                    "relationshipType": "many-to-one"
+                },
+                "parentType": {
+                    "description": "The type of parent used during crossing. Accepted values for this field are 'MALE', 'FEMALE', 'SELF', 'POPULATION', and 'CLONAL'. \n\nIn a pedigree record, the 'parentType' describes each parent of a particular germplasm. \n\nIn a progeny record, the 'parentType' is used to describe how this germplasm was crossed to generate a particular progeny. \nFor example, given a record for germplasm A, having a progeny B and C. The 'parentType' field for progeny B item refers \nto the 'parentType' of A toward B. The 'parentType' field for progeny C item refers to the 'parentType' of A toward C.\nIn this way, A could be a male parent to B, but a female parent to C. ",
+                    "$ref": "ParentType.json#/$defs/ParentType"
+                },
+                "pedigreeNode": {
+                    "description": "associated pedigreeNode",
+                    "$ref": "../BrAPI-Germplasm/PedigreeNode.json#/$defs/PedigreeNode",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "parents"
+                }
+            },
+            "required": [
+                "parentDbId",
+                "parentGermplasm",
+                "parentType"
+            ],
+            "title": "Parents",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+        },
+        "Progeny": {
+            "properties": {
+                "parentDbId": {
+                    "description": "a unique identifiere for a progeny",
+                    "type": "string"
+                },
+                "progenyGermplasm": {
+                    "$ref": "Germplasm.json#/$defs/Germplasm",
+                    "description": "The ID which uniquely identifies a parent germplasm",
+                    "referencedAttribute": "parentPedigreeNodes",
+                    "relationshipType": "many-to-one"
+                },
+                "parentType": {
+                    "description": "The type of parent used during crossing. Accepted values for this field are 'MALE', 'FEMALE', 'SELF', 'POPULATION', and 'CLONAL'. \n\nIn a pedigree record, the 'parentType' describes each parent of a particular germplasm. \n\nIn a progeny record, the 'parentType' is used to describe how this germplasm was crossed to generate a particular progeny. \nFor example, given a record for germplasm A, having a progeny B and C. The 'parentType' field for progeny B item refers \nto the 'parentType' of A toward B. The 'parentType' field for progeny C item refers to the 'parentType' of A toward C.\nIn this way, A could be a male parent to B, but a female parent to C. ",
+                    "$ref": "ParentType.json#/$defs/ParentType"
+                },
+                "pedigreeNode": {
+                    "description": "associated pedigreeNode",
+                    "$ref": "../BrAPI-Germplasm/PedigreeNode.json#/$defs/PedigreeNode",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "parents"
+                }
+            },
+            "required": [
+                "progenyDbId",
+                "progenyGermplasm",
+                "parentType"
+            ],
+            "title": "Progeny",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
             }
         }
     },

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/PlannedCross.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/PlannedCross.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "crossType": {
                     "description": "the type of cross",
@@ -18,8 +26,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/PlannedCross.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/PlannedCross.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "crossType": {
                     "description": "the type of cross",

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/SeedLot.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/SeedLot.json
@@ -24,7 +24,7 @@
                 "contentMixture": {
                     "description": "The mixture of germplasm present in the seed lot.\n<br/>\nIf this seed lot only contains a single germplasm, the response should contain the name \nand DbId of that germplasm with a mixturePercentage value of 100\n<br/>\nIf the seed lot contains a mixture of different germplasm, the response should contain \nthe name and DbId every germplasm present. The mixturePercentage field should contain \nthe ratio of each germplasm in the total mixture. All of the mixturePercentage values \nin this array should sum to equal 100.",
                     "relationshipType": "one-to-many",
-					"referencedAttribute": "seedLot",
+                    "referencedAttribute": "seedLot",
                     "items": {
                         "$ref": "../BrAPI-Germplasm/SeedLot.json#/$defs/ContentMixture",
                         "description": "ContentMixture"

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/SeedLot.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/SeedLot.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "amount": {
                     "description": "The current balance of the amount of material in a SeedLot. Could be a count (seeds, bulbs, etc) or a weight (kg of seed).",
@@ -167,7 +160,7 @@
         },
         "ContentMixture": {
             "properties": {
-                "mixtureDbId": {
+                "contentMixtureDbId": {
                     "description": "The unique DbId for a cross contained in this seed lot",
                     "type": [
                         "null",
@@ -210,7 +203,7 @@
                 }
             },
             "required": [
-                "mixtureDbId"
+                "contentMixtureDbId"
             ],
             "title": "ContentMixture",
             "type": "object",

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/SeedLot.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/SeedLot.json
@@ -160,13 +160,6 @@
         },
         "ContentMixture": {
             "properties": {
-                "contentMixtureDbId": {
-                    "description": "The unique DbId for a cross contained in this seed lot",
-                    "type": [
-                        "null",
-                        "string"
-                    ]
-                },
                 "crossName": {
                     "description": "The human readable name for a cross contained in this seed lot",
                     "type": [
@@ -202,9 +195,6 @@
                     "referencedAttribute": "contentMixture"
                 }
             },
-            "required": [
-                "contentMixtureDbId"
-            ],
             "title": "ContentMixture",
             "type": "object",
             "brapi-metadata": {

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/SeedLot.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/SeedLot.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "amount": {
                     "description": "The current balance of the amount of material in a SeedLot. Could be a count (seeds, bulbs, etc) or a weight (kg of seed).",
@@ -15,46 +23,13 @@
                 },
                 "contentMixture": {
                     "description": "The mixture of germplasm present in the seed lot.\n<br/>\nIf this seed lot only contains a single germplasm, the response should contain the name \nand DbId of that germplasm with a mixturePercentage value of 100\n<br/>\nIf the seed lot contains a mixture of different germplasm, the response should contain \nthe name and DbId every germplasm present. The mixturePercentage field should contain \nthe ratio of each germplasm in the total mixture. All of the mixturePercentage values \nin this array should sum to equal 100.",
+                    "relationshipType": "one-to-many",
+					"referencedAttribute": "seedLot",
                     "items": {
-                        "properties": {
-                            "crossDbId": {
-                                "description": "The unique DbId for a cross contained in this seed lot",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "crossName": {
-                                "description": "The human readable name for a cross contained in this seed lot",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "germplasmDbId": {
-                                "description": "The unique DbId of the Germplasm contained in this Seed Lot",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "germplasmName": {
-                                "description": "The human readable name of the Germplasm contained in this Seed Lot",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "mixturePercentage": {
-                                "description": "The percentage of the given germplasm in the seed lot mixture.",
-                                "type": [
-                                    "null",
-                                    "integer"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "../BrAPI-Germplasm/SeedLot.json#/$defs/ContentMixture",
+                        "description": "ContentMixture"
                     },
+                    "title": "ContentMixture",
                     "type": [
                         "null",
                         "array"
@@ -70,8 +45,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [
@@ -186,6 +163,59 @@
             "type": "object",
             "brapi-metadata": {
                 "primaryModel": true
+            }
+        },
+        "ContentMixture": {
+            "properties": {
+                "mixtureDbId": {
+                    "description": "The unique DbId for a cross contained in this seed lot",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "crossName": {
+                    "description": "The human readable name for a cross contained in this seed lot",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "germplasmDbId": {
+                    "description": "The unique DbId of the Germplasm contained in this Seed Lot",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "germplasmName": {
+                    "description": "The human readable name of the Germplasm contained in this Seed Lot",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "mixturePercentage": {
+                    "description": "The percentage of the given germplasm in the seed lot mixture.",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "seedLot": {
+                    "description": "associated seedLot",
+                    "$ref": "../BrAPI-Germplasm/SeedLot.json#/$defs/SeedLot",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "contentMixture"
+                }
+            },
+            "required": [
+                "mixtureDbId"
+            ],
+            "title": "ContentMixture",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
             }
         }
     },

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/SeedLotTransaction.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/SeedLotTransaction.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "relationshipType": "one-to-one",
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
                 },
                 "amount": {
                     "description": "The number of units being transferred between SeedLots. Could be a count (seeds, bulbs, etc) or a weight (kg of seed).",
@@ -46,7 +39,7 @@
                     "referencedAttribute": "toSeedLotTransactions",
                     "relationshipType": "many-to-one"
                 },
-                "transactionDbId": {
+                "seedLotTransactionDbId": {
                     "description": "Unique DbId for the Seed Lot Transaction",
                     "type": "string"
                 },
@@ -74,7 +67,7 @@
                 }
             },
             "required": [
-                "transactionDbId"
+                "seedLotTransactionDbId"
             ],
             "title": "SeedLotTransaction",
             "type": "object",

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/SeedLotTransaction.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/SeedLotTransaction.json
@@ -39,7 +39,7 @@
                     "referencedAttribute": "toSeedLotTransactions",
                     "relationshipType": "many-to-one"
                 },
-                "seedLotTransactionDbId": {
+                "transactionDbId": {
                     "description": "Unique DbId for the Seed Lot Transaction",
                     "type": "string"
                 },
@@ -67,7 +67,7 @@
                 }
             },
             "required": [
-                "seedLotTransactionDbId"
+                "transactionDbId"
             ],
             "title": "SeedLotTransaction",
             "type": "object",

--- a/Specification/BrAPI-Schema/BrAPI-Germplasm/SeedLotTransaction.json
+++ b/Specification/BrAPI-Schema/BrAPI-Germplasm/SeedLotTransaction.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "amount": {
                     "description": "The number of units being transferred between SeedLots. Could be a count (seeds, bulbs, etc) or a weight (kg of seed).",
@@ -15,8 +23,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/Event.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/Event.json
@@ -17,7 +17,7 @@
                 "eventDateRange": {
                     "description": "An object describing when a particular Event has taken place. An Event can occur at one or more discrete time points (`discreteDates`) or an event can happen continuously over a longer period of time (`startDate`, `endDate`)",
                     "relationshipType": "one-to-many",
-					"referencedAttribute": "event",
+                    "referencedAttribute": "event",
                     "items": {
                         "$ref": "../BrAPI-Phenotyping/Event.json#/$defs/EventDateRange",
                         "description": "EventDateRange"
@@ -42,7 +42,7 @@
                 "eventParameters": {
                     "description": "A list of objects describing additional event parameters. Each of the following accepts a human-readable value or URI",
                     "relationshipType": "one-to-many",
-					"referencedAttribute": "event",
+                    "referencedAttribute": "event",
                     "items": {
                         "$ref": "../BrAPI-Phenotyping/Event.json#/$defs/EventParameters",
                         "description": "EventParameters"

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/Event.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/Event.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "eventDateRange": {
                     "description": "An object describing when a particular Event has taken place. An Event can occur at one or more discrete time points (`discreteDates`) or an event can happen continuously over a longer period of time (`startDate`, `endDate`)",
@@ -44,7 +37,7 @@
                     "relationshipType": "one-to-many",
                     "referencedAttribute": "event",
                     "items": {
-                        "$ref": "../BrAPI-Phenotyping/Event.json#/$defs/EventParameters",
+                        "$ref": "../BrAPI-Phenotyping/Event.json#/$defs/EventParameter",
                         "description": "EventParameters"
                     },
                     "title": "EventParameters",
@@ -95,7 +88,7 @@
         },
         "EventDateRange": {
             "properties": {
-                "rangeDbId": {
+                "eventDateRangeDbId": {
                     "description": "the unique identifier to a event date range",
                     "type": "string"
                 },
@@ -134,7 +127,7 @@
                 }
             },
             "required": [
-                "rangeDbId"
+                "eventDateRangeDbId"
             ],
             "title": "EventDateRange",
             "type": "object",
@@ -142,9 +135,9 @@
                 "primaryModel": false
             }
         },
-        "EventParameters": {
+        "EventParameter": {
             "properties": {
-                "parametersDbId": {
+                "eventParameterDbId": {
                     "description": "The unique identifier to a event",
                     "type": "string"
                 },
@@ -208,7 +201,7 @@
                 }
             },
             "required": [
-                "parametersDbId"
+                "eventParameterDbId"
             ],
             "title": "EventParameters",
             "type": "object",

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/Event.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/Event.json
@@ -4,42 +4,28 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
-                },
-                "eventDateRange": {
-                    "description": "An object describing when a particular Event has taken place. An Event can occur at one or more discrete time points (`discreteDates`) or an event can happen continuously over a longer period of time (`startDate`, `endDate`)",
-                    "properties": {
-                        "discreteDates": {
-                            "description": "A list of dates when the event occurred\n<br/>MIAPPE V1.1 (DM-68) Event date - Date and time of the event.",
-                            "items": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "type": [
-                                "null",
-                                "array"
-                            ]
-                        },
-                        "endDate": {
-                            "description": "The end of a continuous or regularly repetitive event\n<br/>MIAPPE V1.1 (DM-68) Event date - Date and time of the event.",
-                            "format": "date-time",
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        },
-                        "startDate": {
-                            "description": "The beginning of a continuous or regularly repetitive event\n<br/>MIAPPE V1.1 (DM-68) Event date - Date and time of the event.",
-                            "format": "date-time",
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        }
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
                     },
                     "type": [
                         "null",
-                        "object"
+                        "array"
+                    ]
+                },
+                "eventDateRange": {
+                    "description": "An object describing when a particular Event has taken place. An Event can occur at one or more discrete time points (`discreteDates`) or an event can happen continuously over a longer period of time (`startDate`, `endDate`)",
+                    "relationshipType": "one-to-many",
+					"referencedAttribute": "event",
+                    "items": {
+                        "$ref": "../BrAPI-Phenotyping/Event.json#/$defs/EventDateRange",
+                        "description": "EventDateRange"
+                    },
+                    "title": "EventDateRange",
+                    "type": [
+                        "null",
+                        "array"
                     ]
                 },
                 "eventDbId": {
@@ -55,63 +41,13 @@
                 },
                 "eventParameters": {
                     "description": "A list of objects describing additional event parameters. Each of the following accepts a human-readable value or URI",
+                    "relationshipType": "one-to-many",
+					"referencedAttribute": "event",
                     "items": {
-                        "properties": {
-                            "code": {
-                                "description": "The shortened code name of an event parameter\n<br>ICASA \"Code_Display\"",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "description": {
-                                "description": "A human readable description of this event parameter. This description is usually associated with the 'name' and 'code' of an event parameter.",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "name": {
-                                "description": "The full name of an event parameter\n<br>ICASA \"Variable_Name\"",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "units": {
-                                "description": "The units or data type of the 'value'. \n<br>If the 'value' comes from a standardized vocabulary or an encoded list of values, then 'unit' should be 'code'. \n<br>If the 'value' IS NOT a number, then 'unit' should specify a data type eg. 'text', 'boolean', 'date', etc. \n<br>If the value IS a number, then 'unit' should specify the units used eg. 'ml', 'cm', etc\n<br>ICASA \"Unit_or_type\"",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "value": {
-                                "description": "The single value of this event parameter. This single value is accurate for all the dates in the date range. If 'value' is populated then 'valuesByDate' should NOT be populated.",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "valueDescription": {
-                                "description": "If the event parameter 'unit' field is 'code', then use 'valueDescription' to add a human readable description to the value.",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "valuesByDate": {
-                                "description": "An array of values corresponding to each timestamp in the 'discreteDates' array of this event. The 'valuesByDate' array should exactly match the size of the 'discreteDates' array. If 'valuesByDate' is populated then 'value' should NOT be populated.",
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": [
-                                    "null",
-                                    "array"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "../BrAPI-Phenotyping/Event.json#/$defs/EventParameters",
+                        "description": "EventParameters"
                     },
+                    "title": "EventParameters",
                     "type": [
                         "null",
                         "array"
@@ -155,6 +91,129 @@
             "type": "object",
             "brapi-metadata": {
                 "primaryModel": true
+            }
+        },
+        "EventDateRange": {
+            "properties": {
+                "rangeDbId": {
+                    "description": "the unique identifier to a event date range",
+                    "type": "string"
+                },
+                "discreteDates": {
+                    "description": "A list of dates when the event occurred\n<br/>MIAPPE V1.1 (DM-68) Event date - Date and time of the event.",
+                    "items": {
+                        "format": "date-time",
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "endDate": {
+                    "description": "The end of a continuous or regularly repetitive event\n<br/>MIAPPE V1.1 (DM-68) Event date - Date and time of the event.",
+                    "format": "date-time",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "startDate": {
+                    "description": "The beginning of a continuous or regularly repetitive event\n<br/>MIAPPE V1.1 (DM-68) Event date - Date and time of the event.",
+                    "format": "date-time",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "event": {
+                    "description": "associated event",
+                    "$ref": "../BrAPI-Phenotyping/Event.json#/$defs/Event",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "eventDateRange"
+                }
+            },
+            "required": [
+                "rangeDbId"
+            ],
+            "title": "EventDateRange",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+        },
+        "EventParameters": {
+            "properties": {
+                "parametersDbId": {
+                    "description": "The unique identifier to a event",
+                    "type": "string"
+                },
+                "code": {
+                    "description": "The shortened code name of an event parameter\n<br>ICASA \"Code_Display\"",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "description": {
+                    "description": "A human readable description of this event parameter. This description is usually associated with the 'name' and 'code' of an event parameter.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "name": {
+                    "description": "The full name of an event parameter\n<br>ICASA \"Variable_Name\"",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "units": {
+                    "description": "The units or data type of the 'value'. \n<br>If the 'value' comes from a standardized vocabulary or an encoded list of values, then 'unit' should be 'code'. \n<br>If the 'value' IS NOT a number, then 'unit' should specify a data type eg. 'text', 'boolean', 'date', etc. \n<br>If the value IS a number, then 'unit' should specify the units used eg. 'ml', 'cm', etc\n<br>ICASA \"Unit_or_type\"",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "value": {
+                    "description": "The single value of this event parameter. This single value is accurate for all the dates in the date range. If 'value' is populated then 'valuesByDate' should NOT be populated.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "valueDescription": {
+                    "description": "If the event parameter 'unit' field is 'code', then use 'valueDescription' to add a human readable description to the value.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "valuesByDate": {
+                    "description": "An array of values corresponding to each timestamp in the 'discreteDates' array of this event. The 'valuesByDate' array should exactly match the size of the 'discreteDates' array. If 'valuesByDate' is populated then 'value' should NOT be populated.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "event": {
+                    "description": "associated event",
+                    "$ref": "../BrAPI-Phenotyping/Event.json#/$defs/Event",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "eventParameters"
+                }
+            },
+            "required": [
+                "parametersDbId"
+            ],
+            "title": "EventParameters",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
             }
         }
     },

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/Event.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/Event.json
@@ -88,11 +88,7 @@
         },
         "EventDateRange": {
             "properties": {
-                "eventDateRangeDbId": {
-                    "description": "the unique identifier to a event date range",
-                    "type": "string"
-                },
-                "discreteDates": {
+				"discreteDates": {
                     "description": "A list of dates when the event occurred\n<br/>MIAPPE V1.1 (DM-68) Event date - Date and time of the event.",
                     "items": {
                         "format": "date-time",
@@ -126,9 +122,6 @@
                     "referencedAttribute": "eventDateRange"
                 }
             },
-            "required": [
-                "eventDateRangeDbId"
-            ],
             "title": "EventDateRange",
             "type": "object",
             "brapi-metadata": {
@@ -137,10 +130,6 @@
         },
         "EventParameter": {
             "properties": {
-                "eventParameterDbId": {
-                    "description": "The unique identifier to a event",
-                    "type": "string"
-                },
                 "code": {
                     "description": "The shortened code name of an event parameter\n<br>ICASA \"Code_Display\"",
                     "type": [
@@ -200,9 +189,6 @@
                     "referencedAttribute": "eventParameters"
                 }
             },
-            "required": [
-                "eventParameterDbId"
-            ],
             "title": "EventParameters",
             "type": "object",
             "brapi-metadata": {

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/Image.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/Image.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "copyright": {
                     "description": "The copyright information of this image. Example 'Copyright 2018 Bob Robertson'",
@@ -78,17 +71,9 @@
                 },
                 "imageLocation": {
                     "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.\n\nCopied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element.",
-                    "relationshipType": "one-to-many",
+                    "relationshipType": "one-to-one",
                     "referencedAttribute": "image",
-                    "items": {
-                        "$ref": "../BrAPI-Common/GeoJSON.json#/$defs/GeoJSON",
-                        "description": "A geometry as defined by GeoJSON (RFC 7946). In this context, only Point or Polygon geometry are allowed."
-                    },
-                    "title": "GeoJSON",
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+					"$ref": "../BrAPI-Common/GeoJSON.json#/$defs/GeoJSON"
                 },
                 "imageName": {
                     "description": "The human readable name of an image. Might be the same as 'imageFileName', but could be different.",

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/Image.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/Image.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "copyright": {
                     "description": "The copyright information of this image. Example 'Copyright 2018 Bob Robertson'",
@@ -32,8 +40,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [
@@ -68,24 +78,16 @@
                 },
                 "imageLocation": {
                     "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.\n\nCopied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element.",
-                    "properties": {
-                        "geometry": {
-                            "description": "A geometry as defined by GeoJSON (RFC 7946). In this context, only Point or Polygon geometry are allowed.",
-                            "$ref": "../BrAPI-Common/GeoJSONGeometry.json#/$defs/GeoJSONGeometry"
-                        },
-                        "type": {
-                            "default": "Feature",
-                            "description": "The literal string \"Feature\"",
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        }
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "image",
+                    "items": {
+                        "$ref": "../BrAPI-Common/GeoJSON.json#/$defs/GeoJSON",
+                        "description": "A geometry as defined by GeoJSON (RFC 7946). In this context, only Point or Polygon geometry are allowed."
                     },
                     "title": "GeoJSON",
                     "type": [
                         "null",
-                        "object"
+                        "array"
                     ]
                 },
                 "imageName": {

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/Method.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/Method.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "bibliographicalReference": {
                     "description": "Bibliographical reference describing the method.\n<br/>MIAPPE V1.1 (DM-91) Reference associated to the method - URI/DOI of reference describing the method.",
@@ -22,8 +30,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/Method.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/Method.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "bibliographicalReference": {
                     "description": "Bibliographical reference describing the method.\n<br/>MIAPPE V1.1 (DM-91) Reference associated to the method - URI/DOI of reference describing the method.",
@@ -75,6 +68,7 @@
                 },
                 "ontologyReference": {
                     "description": "MIAPPE V1.1\n\n(DM-85) Variable accession number - Accession number of the variable in the Crop Ontology\n\n(DM-87) Trait accession number - Accession number of the trait in a suitable controlled vocabulary (Crop Ontology, Trait Ontology).\n\n(DM-89) Method accession number - Accession number of the method in a suitable controlled vocabulary (Crop Ontology, Trait Ontology).\n\n(DM-93) Scale accession number - Accession number of the scale in a suitable controlled vocabulary (Crop Ontology).",
+                    "relationshipType": "one-to-one",
                     "$ref": "../BrAPI-Phenotyping/OntologyReference.json#/$defs/OntologyReference"
                 }
             },

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/Observation.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/Observation.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "collector": {
                     "description": "The name or identifier of the entity which collected the observation",
@@ -36,17 +29,9 @@
                 },
                 "geoCoordinates": {
                     "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.\n\nCopied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element.",
-                    "relationshipType": "one-to-many",
+                    "relationshipType": "one-to-one",
                     "referencedAttribute": "observation",
-                    "items": {
-                        "$ref": "../BrAPI-Common/GeoJSON.json#/$defs/GeoJSON",
-                        "description": "A geometry as defined by GeoJSON (RFC 7946). In this context, only Point or Polygon geometry are allowed."
-                    },
-                    "title": "GeoJSON",
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+					"$ref": "../BrAPI-Common/GeoJSON.json#/$defs/GeoJSON"
                 },
                 "germplasm": {
                     "$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/Germplasm",

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/Observation.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/Observation.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "collector": {
                     "description": "The name or identifier of the entity which collected the observation",
@@ -15,8 +23,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [
@@ -26,24 +36,16 @@
                 },
                 "geoCoordinates": {
                     "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.\n\nCopied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element.",
-                    "properties": {
-                        "geometry": {
-                            "description": "A geometry as defined by GeoJSON (RFC 7946). In this context, only Point or Polygon geometry are allowed.",
-                            "$ref": "../BrAPI-Common/GeoJSONGeometry.json#/$defs/GeoJSONGeometry"
-                        },
-                        "type": {
-                            "default": "Feature",
-                            "description": "The literal string \"Feature\"",
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        }
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "observation",
+                    "items": {
+                        "$ref": "../BrAPI-Common/GeoJSON.json#/$defs/GeoJSON",
+                        "description": "A geometry as defined by GeoJSON (RFC 7946). In this context, only Point or Polygon geometry are allowed."
                     },
                     "title": "GeoJSON",
                     "type": [
                         "null",
-                        "object"
+                        "array"
                     ]
                 },
                 "germplasm": {

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/ObservationUnit.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/ObservationUnit.json
@@ -66,7 +66,7 @@
                 "observationUnitPosition": {
                     "description": "All positional and layout information related to this Observation Unit \n\nMIAPPE V1.1 (DM-73) Spatial distribution - Type and value of a spatial coordinate (georeference or relative) \nor level of observation (plot 45, subblock 7, block 2) provided as a key-value pair of the form type:value. \nLevels of observation must be consistent with those listed in the Study section.",
                     "relationshipType": "one-to-many",
-					"referencedAttribute": "observationUnit",
+                    "referencedAttribute": "observationUnit",
                     "items": {
                         "$ref": "../BrAPI-Phenotyping/ObservationUnit.json#/$defs/ObservationUnitPosition",
                         "description": "ObservationUnitPosition"
@@ -98,7 +98,7 @@
                 "treatments": {
                     "description": "List of treatments applied to an observation unit.\n\nMIAPPE V1.1 (DM-74) Observation Unit factor value - List of values for each factor applied to the observation unit.",
                     "relationshipType": "one-to-many",
-					"referencedAttribute": "observationUnit",
+                    "referencedAttribute": "observationUnit",
                     "items": {
                         "$ref": "../BrAPI-Phenotyping/ObservationUnit.json#/$defs/Treatments",
                         "description": "Treatments"

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/ObservationUnit.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/ObservationUnit.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "cross": {
                     "$ref": "../BrAPI-Germplasm/Cross.json#/$defs/Cross",
@@ -100,7 +93,7 @@
                     "relationshipType": "one-to-many",
                     "referencedAttribute": "observationUnit",
                     "items": {
-                        "$ref": "../BrAPI-Phenotyping/ObservationUnit.json#/$defs/Treatments",
+                        "$ref": "../BrAPI-Phenotyping/ObservationUnit.json#/$defs/Treatment",
                         "description": "Treatments"
                     },
                     "title": "Treatments",
@@ -183,7 +176,7 @@
         },
         "ObservationUnitPosition": {
             "properties": {
-                "positionDbId": {
+                "observationUnitPositionDbId": {
                     "description": "the unique identifier for a observation unit position",
                     "type": "string"
                 },
@@ -216,10 +209,12 @@
                 },
                 "observationLevel": {
                     "$ref": "../BrAPI-Phenotyping/ObservationUnitLevel.json#/$defs/ObservationUnitLevel",
+                    "relationshipType": "one-to-one",
                     "description": "The exact level and level code of an observation unit. \n\nFor more information on Observation Levels, please review the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Observation_Levels\">Observation Levels documentation</a>. \n\nMIAPPE V1.1 DM-71 Observation unit type \"Type of observation unit in textual form, usually one of the following: study, block, sub-block, plot, sub-plot, pot, plant. Use of other observation unit types is possible but not recommended. \nThe observation unit type can not be used to indicate sub-plant levels. However, observations can still be made on the sub-plant level, as long as the details are indicated in the associated observed variable (see observed variables). \nAlternatively, it is possible to use samples for more detailed tracing of sub-plant units, attaching the observations to them instead.\" "
                 },
                 "observationLevelRelationships": {
                     "description": "Observation levels indicate the granularity level at which the measurements are taken. `levelName` \ndefines the level, `levelOrder` defines where that level exists in the hierarchy of levels. \n`levelOrder`s lower numbers are at the top of the hierarchy (ie field > 0) and higher numbers are \nat the bottom of the hierarchy (ie plant > 6). `levelCode` is an ID code for this level tag. Identify \nthis observation unit by each level of the hierarchy where it exists. \n\nFor more information on Observation Levels, please review the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Observation_Levels\">Observation Levels documentation</a>. \n\n**Standard Level Names: study, field, entry, rep, block, sub-block, plot, sub-plot, plant, pot, sample** ",
+                    "relationshipType": "one-to-one",
                     "items": {
                         "$ref": "../BrAPI-Phenotyping/ObservationUnitLevelRelationship.json#/$defs/ObservationUnitLevelRelationship"
                     },
@@ -286,7 +281,7 @@
                 }
             },
             "required": [
-                "positionDbId"
+                "observationUnitPositionDbId"
             ],
             "title": "ObservationUnitPosition",
             "type": "object",
@@ -294,7 +289,7 @@
                 "primaryModel": false
             }
         },
-        "Treatments": {
+        "Treatment": {
             "properties": {
                 "treatmentDbId": {
                     "description": "the unique identifier for a treatment",

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/ObservationUnit.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/ObservationUnit.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "cross": {
                     "$ref": "../BrAPI-Germplasm/Cross.json#/$defs/Cross",
@@ -14,8 +22,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [
@@ -55,110 +65,16 @@
                 },
                 "observationUnitPosition": {
                     "description": "All positional and layout information related to this Observation Unit \n\nMIAPPE V1.1 (DM-73) Spatial distribution - Type and value of a spatial coordinate (georeference or relative) \nor level of observation (plot 45, subblock 7, block 2) provided as a key-value pair of the form type:value. \nLevels of observation must be consistent with those listed in the Study section.",
-                    "properties": {
-                        "entryType": {
-                            "description": "The type of entry for this observation unit. ex. \"CHECK\", \"TEST\", \"FILLER\"",
-                            "enum": [
-                                "CHECK",
-                                "TEST",
-                                "FILLER",
-                                null
-                            ],
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        },
-                        "geoCoordinates": {
-                            "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.\n\nCopied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element.",
-                            "properties": {
-                                "geometry": {
-                                    "description": "A geometry as defined by GeoJSON (RFC 7946). In this context, only Point or Polygon geometry are allowed.",
-                                    "$ref": "../BrAPI-Common/GeoJSONGeometry.json#/$defs/GeoJSONGeometry"
-                                },
-                                "type": {
-                                    "default": "Feature",
-                                    "description": "The literal string \"Feature\"",
-                                    "type": [
-                                        "null",
-                                        "string"
-                                    ]
-                                }
-                            },
-                            "title": "GeoJSON",
-                            "type": [
-                                "null",
-                                "object"
-                            ]
-                        },
-                        "observationLevel": {
-                            "$ref": "../BrAPI-Phenotyping/ObservationUnitLevel.json#/$defs/ObservationUnitLevel",
-                            "description": "The exact level and level code of an observation unit. \n\nFor more information on Observation Levels, please review the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Observation_Levels\">Observation Levels documentation</a>. \n\nMIAPPE V1.1 DM-71 Observation unit type \"Type of observation unit in textual form, usually one of the following: study, block, sub-block, plot, sub-plot, pot, plant. Use of other observation unit types is possible but not recommended. \nThe observation unit type can not be used to indicate sub-plant levels. However, observations can still be made on the sub-plant level, as long as the details are indicated in the associated observed variable (see observed variables). \nAlternatively, it is possible to use samples for more detailed tracing of sub-plant units, attaching the observations to them instead.\" "
-                        },
-                        "observationLevelRelationships": {
-                            "description": "Observation levels indicate the granularity level at which the measurements are taken. `levelName` \ndefines the level, `levelOrder` defines where that level exists in the hierarchy of levels. \n`levelOrder`s lower numbers are at the top of the hierarchy (ie field > 0) and higher numbers are \nat the bottom of the hierarchy (ie plant > 6). `levelCode` is an ID code for this level tag. Identify \nthis observation unit by each level of the hierarchy where it exists. \n\nFor more information on Observation Levels, please review the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Observation_Levels\">Observation Levels documentation</a>. \n\n**Standard Level Names: study, field, entry, rep, block, sub-block, plot, sub-plot, plant, pot, sample** ",
-                            "items": {
-                                "$ref": "../BrAPI-Phenotyping/ObservationUnitLevelRelationship.json#/$defs/ObservationUnitLevelRelationship"
-                            },
-                            "type": [
-                                "null",
-                                "array"
-                            ]
-                        },
-                        "positionCoordinateX": {
-                            "description": "The X position coordinate for an observation unit. Different systems may use different coordinate systems.",
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        },
-                        "positionCoordinateXType": {
-                            "description": "The type of positional coordinate used. Must be one of the following values \n\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See 'Location Coordinate Encoding' for details \n\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See 'Location Coordinate Encoding' for details \n\nPLANTED_ROW - The physical planted row number \n\nPLANTED_INDIVIDUAL - The physical counted number, could be independent or within a planted row \n\nGRID_ROW - The row index number of a square grid overlay \n\nGRID_COL - The column index number of a square grid overlay \n\nMEASURED_ROW - The distance in meters from a defined 0-th row \n\nMEASURED_COL - The distance in meters from a defined 0-th column ",
-                            "enum": [
-                                "LONGITUDE",
-                                "LATITUDE",
-                                "PLANTED_ROW",
-                                "PLANTED_INDIVIDUAL",
-                                "GRID_ROW",
-                                "GRID_COL",
-                                "MEASURED_ROW",
-                                "MEASURED_COL",
-                                null
-                            ],
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        },
-                        "positionCoordinateY": {
-                            "description": "The Y position coordinate for an observation unit. Different systems may use different coordinate systems.",
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        },
-                        "positionCoordinateYType": {
-                            "description": "The type of positional coordinate used. Must be one of the following values \n\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See 'Location Coordinate Encoding' for details \n\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See 'Location Coordinate Encoding' for details \n\nPLANTED_ROW - The physical planted row number  \n\nPLANTED_INDIVIDUAL - The physical counted number, could be independent or within a planted row \n\nGRID_ROW - The row index number of a square grid overlay \n\nGRID_COL - The column index number of a square grid overlay \n\nMEASURED_ROW - The distance in meters from a defined 0-th row \n\nMEASURED_COL - The distance in meters from a defined 0-th column ",
-                            "enum": [
-                                "LONGITUDE",
-                                "LATITUDE",
-                                "PLANTED_ROW",
-                                "PLANTED_INDIVIDUAL",
-                                "GRID_ROW",
-                                "GRID_COL",
-                                "MEASURED_ROW",
-                                "MEASURED_COL",
-                                null
-                            ],
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        }
+                    "relationshipType": "one-to-many",
+					"referencedAttribute": "observationUnit",
+                    "items": {
+                        "$ref": "../BrAPI-Phenotyping/ObservationUnit.json#/$defs/ObservationUnitPosition",
+                        "description": "ObservationUnitPosition"
                     },
+                    "title": "ObservationUnitPosition",
                     "type": [
                         "null",
-                        "object"
+                        "array"
                     ]
                 },
                 "program": {
@@ -181,25 +97,13 @@
                 },
                 "treatments": {
                     "description": "List of treatments applied to an observation unit.\n\nMIAPPE V1.1 (DM-74) Observation Unit factor value - List of values for each factor applied to the observation unit.",
+                    "relationshipType": "one-to-many",
+					"referencedAttribute": "observationUnit",
                     "items": {
-                        "properties": {
-                            "factor": {
-                                "description": "The type of treatment/factor. ex. 'fertilizer', 'inoculation', 'irrigation', etc\n\nMIAPPE V1.1 (DM-61) Experimental Factor type - Name/Acronym of the experimental factor.",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "modality": {
-                                "description": "The treatment/factor description. ex. 'low fertilizer', 'yellow rust inoculation', 'high water', etc\n\nMIAPPE V1.1 (DM-62) Experimental Factor description - Free text description of the experimental factor. This includes all relevant treatments planned and protocol planned for all the plants targeted by a given experimental factor. ",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "../BrAPI-Phenotyping/ObservationUnit.json#/$defs/Treatments",
+                        "description": "Treatments"
                     },
+                    "title": "Treatments",
                     "type": [
                         "null",
                         "array"
@@ -275,6 +179,155 @@
             "type": "object",
             "brapi-metadata": {
                 "primaryModel": true
+            }
+        },
+        "ObservationUnitPosition": {
+            "properties": {
+                "positionDbId": {
+                    "description": "the unique identifier for a observation unit position",
+                    "type": "string"
+                },
+                "entryType": {
+                    "description": "The type of entry for this observation unit. ex. \"CHECK\", \"TEST\", \"FILLER\"",
+                    "enum": [
+                        "CHECK",
+                        "TEST",
+                        "FILLER",
+                        null
+                    ],
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "geoCoordinates": {
+                    "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.\n\nCopied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element.",
+                    "relationshipType": "one-to-many",
+                    "referencedAttribute": "observationUnit",
+                    "items": {
+                        "$ref": "../BrAPI-Common/GeoJSON.json#/$defs/GeoJSON",
+                        "description": "A geometry as defined by GeoJSON (RFC 7946). In this context, only Point or Polygon geometry are allowed."
+                    },
+                    "title": "GeoJSON",
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "observationLevel": {
+                    "$ref": "../BrAPI-Phenotyping/ObservationUnitLevel.json#/$defs/ObservationUnitLevel",
+                    "description": "The exact level and level code of an observation unit. \n\nFor more information on Observation Levels, please review the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Observation_Levels\">Observation Levels documentation</a>. \n\nMIAPPE V1.1 DM-71 Observation unit type \"Type of observation unit in textual form, usually one of the following: study, block, sub-block, plot, sub-plot, pot, plant. Use of other observation unit types is possible but not recommended. \nThe observation unit type can not be used to indicate sub-plant levels. However, observations can still be made on the sub-plant level, as long as the details are indicated in the associated observed variable (see observed variables). \nAlternatively, it is possible to use samples for more detailed tracing of sub-plant units, attaching the observations to them instead.\" "
+                },
+                "observationLevelRelationships": {
+                    "description": "Observation levels indicate the granularity level at which the measurements are taken. `levelName` \ndefines the level, `levelOrder` defines where that level exists in the hierarchy of levels. \n`levelOrder`s lower numbers are at the top of the hierarchy (ie field > 0) and higher numbers are \nat the bottom of the hierarchy (ie plant > 6). `levelCode` is an ID code for this level tag. Identify \nthis observation unit by each level of the hierarchy where it exists. \n\nFor more information on Observation Levels, please review the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Observation_Levels\">Observation Levels documentation</a>. \n\n**Standard Level Names: study, field, entry, rep, block, sub-block, plot, sub-plot, plant, pot, sample** ",
+                    "items": {
+                        "$ref": "../BrAPI-Phenotyping/ObservationUnitLevelRelationship.json#/$defs/ObservationUnitLevelRelationship"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "positionCoordinateX": {
+                    "description": "The X position coordinate for an observation unit. Different systems may use different coordinate systems.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "positionCoordinateXType": {
+                    "description": "The type of positional coordinate used. Must be one of the following values \n\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See 'Location Coordinate Encoding' for details \n\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See 'Location Coordinate Encoding' for details \n\nPLANTED_ROW - The physical planted row number \n\nPLANTED_INDIVIDUAL - The physical counted number, could be independent or within a planted row \n\nGRID_ROW - The row index number of a square grid overlay \n\nGRID_COL - The column index number of a square grid overlay \n\nMEASURED_ROW - The distance in meters from a defined 0-th row \n\nMEASURED_COL - The distance in meters from a defined 0-th column ",
+                    "enum": [
+                        "LONGITUDE",
+                        "LATITUDE",
+                        "PLANTED_ROW",
+                        "PLANTED_INDIVIDUAL",
+                        "GRID_ROW",
+                        "GRID_COL",
+                        "MEASURED_ROW",
+                        "MEASURED_COL",
+                        null
+                    ],
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "positionCoordinateY": {
+                    "description": "The Y position coordinate for an observation unit. Different systems may use different coordinate systems.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "positionCoordinateYType": {
+                    "description": "The type of positional coordinate used. Must be one of the following values \n\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See 'Location Coordinate Encoding' for details \n\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See 'Location Coordinate Encoding' for details \n\nPLANTED_ROW - The physical planted row number  \n\nPLANTED_INDIVIDUAL - The physical counted number, could be independent or within a planted row \n\nGRID_ROW - The row index number of a square grid overlay \n\nGRID_COL - The column index number of a square grid overlay \n\nMEASURED_ROW - The distance in meters from a defined 0-th row \n\nMEASURED_COL - The distance in meters from a defined 0-th column ",
+                    "enum": [
+                        "LONGITUDE",
+                        "LATITUDE",
+                        "PLANTED_ROW",
+                        "PLANTED_INDIVIDUAL",
+                        "GRID_ROW",
+                        "GRID_COL",
+                        "MEASURED_ROW",
+                        "MEASURED_COL",
+                        null
+                    ],
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "observationUnit": {
+                    "description": "associated observation Unit",
+                    "$ref": "../BrAPI-Phenotyping/ObservationUnit.json#/$defs/ObservationUnit",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "observationUnitPosition"
+                }
+            },
+            "required": [
+                "positionDbId"
+            ],
+            "title": "ObservationUnitPosition",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+        },
+        "Treatments": {
+            "properties": {
+                "treatmentDbId": {
+                    "description": "the unique identifier for a treatment",
+                    "type": "string"
+                },
+                "factor": {
+                    "description": "The type of treatment/factor. ex. 'fertilizer', 'inoculation', 'irrigation', etc\n\nMIAPPE V1.1 (DM-61) Experimental Factor type - Name/Acronym of the experimental factor.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "modality": {
+                    "description": "The treatment/factor description. ex. 'low fertilizer', 'yellow rust inoculation', 'high water', etc\n\nMIAPPE V1.1 (DM-62) Experimental Factor description - Free text description of the experimental factor. This includes all relevant treatments planned and protocol planned for all the plants targeted by a given experimental factor. ",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "observationUnit": {
+                    "description": "associated observation Unit",
+                    "$ref": "../BrAPI-Phenotyping/ObservationUnit.json#/$defs/ObservationUnit",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "treatments"
+                }
+            },
+            "required": [
+                "treatmentDbId"
+            ],
+            "title": "Treatments",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
             }
         }
     },

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/ObservationUnit.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/ObservationUnit.json
@@ -176,10 +176,6 @@
         },
         "ObservationUnitPosition": {
             "properties": {
-                "observationUnitPositionDbId": {
-                    "description": "the unique identifier for a observation unit position",
-                    "type": "string"
-                },
                 "entryType": {
                     "description": "The type of entry for this observation unit. ex. \"CHECK\", \"TEST\", \"FILLER\"",
                     "enum": [
@@ -280,9 +276,6 @@
                     "referencedAttribute": "observationUnitPosition"
                 }
             },
-            "required": [
-                "observationUnitPositionDbId"
-            ],
             "title": "ObservationUnitPosition",
             "type": "object",
             "brapi-metadata": {

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/ObservationUnitLevel.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/ObservationUnitLevel.json
@@ -23,6 +23,13 @@
                         "null",
                         "integer"
                     ]
+                },
+				"observationUnitLevelDbId": {
+                    "description": "The ID which uniquely identifies a observation unit level",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
                 }
             },
             "required": [],

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/ObservationUnitLevelRelationship.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/ObservationUnitLevelRelationship.json
@@ -30,6 +30,13 @@
                         "null",
                         "string"
                     ]
+                },
+				"observationUnitLevelRelationshipDbId": {
+                    "description": "The ID which uniquely identifies a observaton unit level relationship",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
                 }
             },
             "title": "ObservationUnitLevelRelationship",

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/Ontology.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/Ontology.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "authors": {
                     "description": "Ontology's list of authors (no specific format)",

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/Ontology.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/Ontology.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "authors": {
                     "description": "Ontology's list of authors (no specific format)",

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/OntologyReference.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/OntologyReference.json
@@ -47,10 +47,6 @@
         },
         "DocumentationLink": {
             "properties": {
-                "documentationLinkDbId": {
-                    "description": "the unique identifier for a documentation link",
-                    "type": "string"
-                },
                 "URL": {
                     "format": "uri",
                     "type": [
@@ -77,9 +73,6 @@
                     "referencedAttribute": "documentationLinks"
                 }
             },
-            "required": [
-                "linkDbId"
-            ],
             "title": "DocumentationLinks",
             "type": "object",
             "brapi-metadata": {

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/OntologyReference.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/OntologyReference.json
@@ -5,7 +5,7 @@
                 "documentationLinks": {
                     "description": "links to various ontology documentation",
                     "relationshipType": "one-to-many",
-					"referencedAttribute": "ontologyReference",
+                    "referencedAttribute": "ontologyReference",
                     "items": {
                         "$ref": "../BrAPI-Phenotyping/OntologyReference.json#/$defs/DocumentationLinks",
                         "description": "DocumentationLinks"

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/OntologyReference.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/OntologyReference.json
@@ -7,7 +7,7 @@
                     "relationshipType": "one-to-many",
                     "referencedAttribute": "ontologyReference",
                     "items": {
-                        "$ref": "../BrAPI-Phenotyping/OntologyReference.json#/$defs/DocumentationLinks",
+                        "$ref": "../BrAPI-Phenotyping/OntologyReference.json#/$defs/DocumentationLink",
                         "description": "DocumentationLinks"
                     },
                     "title": "DocumentationLinks",
@@ -18,7 +18,15 @@
                 },
                 "ontology": {
                     "description": "The Ontology for this reference",
+                    "relationshipType": "one-to-one",
                     "$ref": "../BrAPI-Phenotyping/Ontology.json#/$defs/Ontology"
+                },
+				"ontologyReferenceDbId": {
+                    "description": "The ID which uniquely identifies a ontology reference",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
                 },
                 "version": {
                     "description": "Ontology version (no specific format)",
@@ -37,9 +45,9 @@
                 "primaryModel": false
             }
         },
-        "DocumentationLinks": {
+        "DocumentationLink": {
             "properties": {
-                "linkDbId": {
+                "documentationLinkDbId": {
                     "description": "the unique identifier for a documentation link",
                     "type": "string"
                 },

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/OntologyReference.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/OntologyReference.json
@@ -4,30 +4,13 @@
             "properties": {
                 "documentationLinks": {
                     "description": "links to various ontology documentation",
+                    "relationshipType": "one-to-many",
+					"referencedAttribute": "ontologyReference",
                     "items": {
-                        "properties": {
-                            "URL": {
-                                "format": "uri",
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            },
-                            "type": {
-                                "enum": [
-                                    "OBO",
-                                    "RDF",
-                                    "WEBPAGE",
-                                    null
-                                ],
-                                "type": [
-                                    "null",
-                                    "string"
-                                ]
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "../BrAPI-Phenotyping/OntologyReference.json#/$defs/DocumentationLinks",
+                        "description": "DocumentationLinks"
                     },
+                    "title": "DocumentationLinks",
                     "type": [
                         "null",
                         "array"
@@ -49,6 +32,47 @@
                 "ontology"
             ],
             "title": "OntologyReference",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+        },
+        "DocumentationLinks": {
+            "properties": {
+                "linkDbId": {
+                    "description": "the unique identifier for a documentation link",
+                    "type": "string"
+                },
+                "URL": {
+                    "format": "uri",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "type": {
+                    "enum": [
+                        "OBO",
+                        "RDF",
+                        "WEBPAGE",
+                        null
+                    ],
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "ontologyReference": {
+                    "description": "associated ontology reference",
+                    "$ref": "../BrAPI-Phenotyping/OntologyReference.json#/$defs/OntologyReference",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "documentationLinks"
+                }
+            },
+            "required": [
+                "linkDbId"
+            ],
+            "title": "DocumentationLinks",
             "type": "object",
             "brapi-metadata": {
                 "primaryModel": false

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/Scale.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/Scale.json
@@ -95,12 +95,8 @@
                 "primaryModel": true
             }
         },
-        "ValidValue": {
+        "ValidValues": {
             "properties": {
-                "validValueDbId": {
-                    "description": "the unique identifier of a valid value",
-                    "type": "string"
-                },
                 "categories": {
                     "description": "List of possible values with optional labels",
                     "relationshipType": "one-to-many",
@@ -136,9 +132,6 @@
                     "referencedAttribute": "validValues"
                 }
             },
-            "required": [
-                "validValueDbId"
-            ],
             "title": "ValidValues",
             "type": "object",
             "brapi-metadata": {
@@ -147,10 +140,6 @@
         },
         "Category": {
             "properties": {
-                "categoryDbId": {
-                    "description": "the unique identifier of a category",
-                    "type": "string"
-                },
                 "label": {
                     "description": "A text label for a category",
                     "type": [
@@ -167,14 +156,11 @@
                 },
                 "validValues": {
                     "description": "associated valid values",
-                    "$ref": "../BrAPI-Phenotyping/Scale.json#/$defs/ValidValue",
+                    "$ref": "../BrAPI-Phenotyping/Scale.json#/$defs/ValidValues",
                     "relationshipType": "many-to-one",
                     "referencedAttribute": "categories"
                 }
             },
-            "required": [
-                "categoriesDbId"
-            ],
             "title": "Categories",
             "type": "object",
             "brapi-metadata": {

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/Scale.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/Scale.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "dataType": {
                     "description": "<p>Class of the scale, entries can be</p>\n<p>\"Code\" -  This scale class is exceptionally used to express complex traits. Code is a nominal scale that combines the expressions of the different traits composing the complex trait. For example a severity trait might be expressed by a 2 digit and 2 character code. The first 2 digits are the percentage of the plant covered by a fungus and the 2 characters refer to the delay in development, e.g. \"75VD\" means \"75 %\" of the plant is infected and the plant is very delayed.</p>\n<p>\"Date\" - The date class is for events expressed in a time format, See ISO 8601</p>\n<p>\"Duration\" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months</p>\n<p>\"Nominal\" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories</p>\n<p>\"Numerical\" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectare, branches</p>\n<p>\"Ordinal\" - Ordinal scales are scales composed of ordered categories</p>\n<p>\"Text\" - A free text is used to express the trait.</p>",
@@ -53,6 +46,7 @@
                 },
                 "ontologyReference": {
                     "description": "MIAPPE V1.1\n\n(DM-85) Variable accession number - Accession number of the variable in the Crop Ontology\n\n(DM-87) Trait accession number - Accession number of the trait in a suitable controlled vocabulary (Crop Ontology, Trait Ontology).\n\n(DM-89) Method accession number - Accession number of the method in a suitable controlled vocabulary (Crop Ontology, Trait Ontology).\n\n(DM-93) Scale accession number - Accession number of the scale in a suitable controlled vocabulary (Crop Ontology).",
+                    "relationshipType": "one-to-one",
                     "$ref": "../BrAPI-Phenotyping/OntologyReference.json#/$defs/OntologyReference"
                 },
                 "scaleDbId": {
@@ -81,7 +75,7 @@
                     "relationshipType": "one-to-many",
                     "referencedAttribute": "scale",
                     "items": {
-                        "$ref": "../BrAPI-Phenotyping/Scale.json#/$defs/ValidValues",
+                        "$ref": "../BrAPI-Phenotyping/Scale.json#/$defs/ValidValue",
                         "description": "ValidValues"
                     },
                     "title": "ValidValues",
@@ -101,9 +95,9 @@
                 "primaryModel": true
             }
         },
-        "ValidValues": {
+        "ValidValue": {
             "properties": {
-                "validValuesDbId": {
+                "validValueDbId": {
                     "description": "the unique identifier of a valid value",
                     "type": "string"
                 },
@@ -112,7 +106,7 @@
                     "relationshipType": "one-to-many",
                     "referencedAttribute": "validValues",
                     "items": {
-                        "$ref": "../BrAPI-Phenotyping/Scale.json#/$defs/Categories",
+                        "$ref": "../BrAPI-Phenotyping/Scale.json#/$defs/Category",
                         "description": "Categories"
                     },
                     "title": "Categories",
@@ -143,7 +137,7 @@
                 }
             },
             "required": [
-                "validValuesDbId"
+                "validValueDbId"
             ],
             "title": "ValidValues",
             "type": "object",
@@ -151,9 +145,9 @@
                 "primaryModel": false
             }
         },
-        "Categories": {
+        "Category": {
             "properties": {
-                "categoriesDbId": {
+                "categoryDbId": {
                     "description": "the unique identifier of a category",
                     "type": "string"
                 },
@@ -173,7 +167,7 @@
                 },
                 "validValues": {
                     "description": "associated valid values",
-                    "$ref": "../BrAPI-Phenotyping/Scale.json#/$defs/ValidValues",
+                    "$ref": "../BrAPI-Phenotyping/Scale.json#/$defs/ValidValue",
                     "relationshipType": "many-to-one",
                     "referencedAttribute": "categories"
                 }

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/Scale.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/Scale.json
@@ -79,7 +79,7 @@
                 },
                 "validValues": {
                     "relationshipType": "one-to-many",
-					"referencedAttribute": "scale",
+                    "referencedAttribute": "scale",
                     "items": {
                         "$ref": "../BrAPI-Phenotyping/Scale.json#/$defs/ValidValues",
                         "description": "ValidValues"
@@ -110,7 +110,7 @@
                 "categories": {
                     "description": "List of possible values with optional labels",
                     "relationshipType": "one-to-many",
-					"referencedAttribute": "validValues",
+                    "referencedAttribute": "validValues",
                     "items": {
                         "$ref": "../BrAPI-Phenotyping/Scale.json#/$defs/Categories",
                         "description": "Categories"
@@ -154,7 +154,7 @@
         "Categories": {
             "properties": {
                 "categoriesDbId": {
-                   "description": "the unique identifier of a category",
+                    "description": "the unique identifier of a category",
                     "type": "string"
                 },
                 "label": {

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/Scale.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/Scale.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "dataType": {
                     "description": "<p>Class of the scale, entries can be</p>\n<p>\"Code\" -  This scale class is exceptionally used to express complex traits. Code is a nominal scale that combines the expressions of the different traits composing the complex trait. For example a severity trait might be expressed by a 2 digit and 2 character code. The first 2 digits are the percentage of the plant covered by a fungus and the 2 characters refer to the delay in development, e.g. \"75VD\" means \"75 %\" of the plant is infected and the plant is very delayed.</p>\n<p>\"Date\" - The date class is for events expressed in a time format, See ISO 8601</p>\n<p>\"Duration\" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months</p>\n<p>\"Nominal\" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories</p>\n<p>\"Numerical\" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectare, branches</p>\n<p>\"Ordinal\" - Ordinal scales are scales composed of ordered categories</p>\n<p>\"Text\" - A free text is used to express the trait.</p>",
@@ -32,8 +40,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [
@@ -68,51 +78,16 @@
                     ]
                 },
                 "validValues": {
-                    "properties": {
-                        "categories": {
-                            "description": "List of possible values with optional labels",
-                            "items": {
-                                "properties": {
-                                    "label": {
-                                        "description": "A text label for a category",
-                                        "type": [
-                                            "null",
-                                            "string"
-                                        ]
-                                    },
-                                    "value": {
-                                        "description": "The actual value for a category",
-                                        "type": [
-                                            "null",
-                                            "string"
-                                        ]
-                                    }
-                                },
-                                "type": "object"
-                            },
-                            "type": [
-                                "null",
-                                "array"
-                            ]
-                        },
-                        "maximumValue": {
-                            "description": "Maximum value for numerical, date, and time scales. Typically used for data capture control and QC.",
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        },
-                        "minimumValue": {
-                            "description": "Minimum value for numerical, date, and time scales. Typically used for data capture control and QC.",
-                            "type": [
-                                "null",
-                                "string"
-                            ]
-                        }
+                    "relationshipType": "one-to-many",
+					"referencedAttribute": "scale",
+                    "items": {
+                        "$ref": "../BrAPI-Phenotyping/Scale.json#/$defs/ValidValues",
+                        "description": "ValidValues"
                     },
+                    "title": "ValidValues",
                     "type": [
                         "null",
-                        "object"
+                        "array"
                     ]
                 }
             },
@@ -124,6 +99,92 @@
             "type": "object",
             "brapi-metadata": {
                 "primaryModel": true
+            }
+        },
+        "ValidValues": {
+            "properties": {
+                "validValuesDbId": {
+                    "description": "the unique identifier of a valid value",
+                    "type": "string"
+                },
+                "categories": {
+                    "description": "List of possible values with optional labels",
+                    "relationshipType": "one-to-many",
+					"referencedAttribute": "validValues",
+                    "items": {
+                        "$ref": "../BrAPI-Phenotyping/Scale.json#/$defs/Categories",
+                        "description": "Categories"
+                    },
+                    "title": "Categories",
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "maximumValue": {
+                    "description": "Maximum value for numerical, date, and time scales. Typically used for data capture control and QC.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "minimumValue": {
+                    "description": "Minimum value for numerical, date, and time scales. Typically used for data capture control and QC.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "scale": {
+                    "description": "associated scale",
+                    "$ref": "../BrAPI-Phenotyping/Scale.json#/$defs/Scale",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "validValues"
+                }
+            },
+            "required": [
+                "validValuesDbId"
+            ],
+            "title": "ValidValues",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
+            }
+        },
+        "Categories": {
+            "properties": {
+                "categoriesDbId": {
+                   "description": "the unique identifier of a category",
+                    "type": "string"
+                },
+                "label": {
+                    "description": "A text label for a category",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "value": {
+                    "description": "The actual value for a category",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "validValues": {
+                    "description": "associated valid values",
+                    "$ref": "../BrAPI-Phenotyping/Scale.json#/$defs/ValidValues",
+                    "relationshipType": "many-to-one",
+                    "referencedAttribute": "categories"
+                }
+            },
+            "required": [
+                "categoriesDbId"
+            ],
+            "title": "Categories",
+            "type": "object",
+            "brapi-metadata": {
+                "primaryModel": false
             }
         }
     },

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/Trait.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/Trait.json
@@ -4,15 +4,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "relationshipType": "one-to-many",
-                    "items": {
-                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
-                        "description": "AdditionalInfo"
-                    },
-                    "type": [
-                        "null",
-                        "array"
-                    ]
+                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+					"relationshipType": "one-to-one"
                 },
                 "alternativeAbbreviations": {
                     "description": "A list of shortened, human readable, names for a Trait. These abbreviations are acceptable alternatives to the mainAbbreviation and do not need to follow any formatting convention.",
@@ -74,6 +67,7 @@
                 },
                 "ontologyReference": {
                     "description": "MIAPPE V1.1\n\n(DM-85) Variable accession number - Accession number of the variable in the Crop Ontology\n\n(DM-87) Trait accession number - Accession number of the trait in a suitable controlled vocabulary (Crop Ontology, Trait Ontology).\n\n(DM-89) Method accession number - Accession number of the method in a suitable controlled vocabulary (Crop Ontology, Trait Ontology).\n\n(DM-93) Scale accession number - Accession number of the scale in a suitable controlled vocabulary (Crop Ontology).",
+                    "relationshipType": "one-to-one",
                     "$ref": "../BrAPI-Phenotyping/OntologyReference.json#/$defs/OntologyReference"
                 },
                 "status": {

--- a/Specification/BrAPI-Schema/BrAPI-Phenotyping/Trait.json
+++ b/Specification/BrAPI-Schema/BrAPI-Phenotyping/Trait.json
@@ -4,7 +4,15 @@
             "properties": {
                 "additionalInfo": {
                     "description": "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification.",
-                    "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo"
+                    "relationshipType": "one-to-many",
+                    "items": {
+                        "$ref": "../BrAPI-Common/AdditionalInfo.json#/$defs/AdditionalInfo",
+                        "description": "AdditionalInfo"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "alternativeAbbreviations": {
                     "description": "A list of shortened, human readable, names for a Trait. These abbreviations are acceptable alternatives to the mainAbbreviation and do not need to follow any formatting convention.",
@@ -46,8 +54,10 @@
                 },
                 "externalReferences": {
                     "description": "An array of external reference ids. These are references to this piece of data in an external system. Could be a simple string or a URI.",
+                    "relationshipType": "one-to-many",
                     "items": {
-                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference"
+                        "$ref": "../BrAPI-Common/ExternalReference.json#/$defs/ExternalReference",
+                        "description": "ExternalReferences"
                     },
                     "title": "ExternalReferences",
                     "type": [

--- a/Specification/BrAPI-Schema/Requests/CrossingProjectRequest.json
+++ b/Specification/BrAPI-Schema/Requests/CrossingProjectRequest.json
@@ -29,7 +29,7 @@
                             "description": "If the parameter 'includePotentialParents' is false, the array 'potentialParents' should be empty, null, or excluded from the response object.",
                             "type": "boolean"
                         }
-                     }
+                    }
                 }
             ],
             "brapi-metadata": {

--- a/Specification/BrAPI-Schema/Requests/GermplasmRequest.json
+++ b/Specification/BrAPI-Schema/Requests/GermplasmRequest.json
@@ -17,7 +17,6 @@
                 {
                     "$ref": "Parameters/TrialParameters.json#/$defs/TrialParameters"
                 },
-
                 {
                     "type": "object",
                     "properties": {

--- a/Specification/BrAPI-Schema/Requests/PedigreeNodeRequest.json
+++ b/Specification/BrAPI-Schema/Requests/PedigreeNodeRequest.json
@@ -17,7 +17,6 @@
                 {
                     "$ref": "Parameters/TrialParameters.json#/$defs/TrialParameters"
                 },
-
                 {
                     "type": "object",
                     "properties": {

--- a/Specification/BrAPI-Schema/Requests/SampleRequest.json
+++ b/Specification/BrAPI-Schema/Requests/SampleRequest.json
@@ -2,7 +2,6 @@
     "$defs": {
         "SampleRequest": {
             "allOf": [
-
                 {
                     "$ref": "Parameters/CommonCropNamesParameters.json#/$defs/CommonCropNamesParameters"
                 },
@@ -18,7 +17,6 @@
                 {
                     "$ref": "Parameters/TrialParameters.json#/$defs/TrialParameters"
                 },
-
                 {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
Dear @BrapiCoordinatorSelby,

@VivianBass and I finished the editing of the schemas. Like we talked about, we added the `relationshipType` to every occurence of the attributes `additionalInfo` and `externalReferences` in every model. Also we flattend all models, so there shouldn`t be a nested model left or rather all models should be 1-dimensional. (As in Wittenberg, we proceeded here using separate models and associations).

In some models there were location specifications (such as ImageLocation in Image.json). These attributes were effectively just a copy of GeoJSON, although GeoJSON exists as an independent model. Accordingly, we have changed the attributes so that they form an association to GeoJSON: GeoJSON
```json
"GeoJSON": {
	"title": "GeoJSON",
	"type": "object",
	"description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.\n\nCopied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element.",
	"properties": {
		"geometryDbId": {
			"description": "Unique identifier for the geometry",
			"type": [
				"null",
				"string"
			]
		},
		"geometry": {
			"description": "A geometry as defined by GeoJSON (RFC 7946). In this context, only Point or Polygon geometry are allowed.",
			"$ref": "GeoJSONGeometry.json#/$defs/GeoJSONGeometry"
		},
		"type": {
			"type": "string",
			"default": "Feature",
			"example": "Feature",
			"description": "The literal string \"Feature\""
		},
		"image": {
			"description": "Geometry associated with an image",
			"$ref": "../BrAPI-Phenotyping/Image.json#/$defs/Image",
			"relationshipType": "many-to-one",
			"referencedAttribute": "imageLocation"
		},
		"observation": {
			"description": "Geometry associated with an image",
			"$ref": "../BrAPI-Phenotyping/Observation.json#/$defs/Observation",
			"relationshipType": "many-to-one",
			"referencedAttribute": "geoCoordinates"
		},
		"observationUnit": {
			"description": "Geometry associated with an image",
			"$ref": "../BrAPI-Phenotyping/ObservationUnit.json#/$defs/ObservationUnitPosition",
			"relationshipType": "many-to-one",
			"referencedAttribute": "geoCoordinates"
		},
		"germplasmOrigin": {
			"description": "Geometry associated with an image",
			"$ref": "../BrAPI-Germplasm/Germplasm.json#/$defs/GermplasmOrigin",
			"relationshipType": "many-to-one",
			"referencedAttribute": "coordinates"
		}
	},
	"required": [
		"geometryDbId"
	]
}
```

New `ImageLocation` from `Image.json`:
```json
"imageLocation": {
	"description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.\n\nCopied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element.",
	"relationshipType": "one-to-many",
	"referencedAttribute": "image",
	"items": {
		"$ref": "../BrAPI-Common/GeoJSON.json#/$defs/GeoJSON",
		"description": "A geometry as defined by GeoJSON (RFC 7946). In this context, only Point or Polygon geometry are allowed."
	},
	"title": "GeoJSON",
	"type": [
		"null",
		"array"
	]
}
```
Could you please check or changes, if there is something wrong or if you like us to change other things?

Thank you and best regards! :)